### PR TITLE
feat!: allow passing of base URL as string

### DIFF
--- a/examples/kafkainstance/kafka_instance.go
+++ b/examples/kafkainstance/kafka_instance.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 	"context"
 	"fmt"
 	"os"
@@ -19,9 +18,9 @@ func main() {
 
 	apiClient := kafkainstanceapi.NewAPIClient(&kafkainstanceapi.Config{
 		HTTPClient: tc,
+		Debug:      true,
+		BaseURL:    "http://localhost:9000/custom/path/to/rest",
 	})
-
-	x := kafkainstance.Topic{}
 
 	res, _, err := apiClient.DefaultApi.GetTopics(context.Background()).Execute()
 	if err != nil {

--- a/internal/api_config.go
+++ b/internal/api_config.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"net/http"
-	"net/url"
 )
 
 // APIConfig defines the available configuration options
@@ -11,7 +10,7 @@ type APIConfig struct {
 	// HTTPClient is a custom HTTP client
 	HTTPClient *http.Client
 	// Debug enables debug-level logging
-	Debug      bool
-	// ServerURL sets a custom API server base URL
-	ServerURL  *url.URL
+	Debug bool
+	// BaseURL sets a custom API server base URL
+	BaseURL string
 }

--- a/kafkainstance/apiv1internal/README.md
+++ b/kafkainstance/apiv1internal/README.md
@@ -39,11 +39,10 @@ kafkas, resp, err := client.DefaultApi.GetTopics(context.Background()).Execute()
 You can override the default configuration options:
 
 ```go
-baseURL, _ := url.Parse("http://localhost:8001")
 cfg := kafkainstance.Config{
     HTTPClient: yourHTTPClient,
     Debug: true,
-    ServerURL: baseURL,
+    BaseURL: "http://localhost:8001/rest",
 }
 
 client := kafkainstance.NewAPIClient(&cfg)

--- a/kafkainstance/apiv1internal/api_client.go
+++ b/kafkainstance/apiv1internal/api_client.go
@@ -21,9 +21,12 @@ func NewAPIClient(cfg *Config) *apiv1.APIClient {
 	if cfg.HTTPClient != nil {
 		apiCfg.HTTPClient = cfg.HTTPClient
 	}
-	if cfg.ServerURL != nil {
-		apiCfg.Host = cfg.ServerURL.Host
-		apiCfg.Scheme = cfg.ServerURL.Scheme
+	if cfg.BaseURL != "" {
+		apiCfg.Servers = []apiv1.ServerConfiguration{
+			{
+				URL: cfg.BaseURL,
+			},
+		}
 	}
 
 	apiCfg.Debug = cfg.Debug

--- a/kafkamgmt/apiv1/README.md
+++ b/kafkamgmt/apiv1/README.md
@@ -39,11 +39,10 @@ kafkas, resp, err := client.DefaultApi.GetKafkas(context.Background()).Execute()
 You can override the default configuration options:
 
 ```go
-baseURL, _ := url.Parse("http://localhost:8001")
 cfg := kafkamgmt.Config{
     HTTPClient: yourHTTPClient,
     Debug: true,
-    ServerURL: baseURL,
+    BaseURL: "http://localhost:8080",
 }
 
 client := kafkamgmt.NewAPIClient(&cfg)

--- a/kafkamgmt/apiv1/api_client.go
+++ b/kafkamgmt/apiv1/api_client.go
@@ -21,9 +21,12 @@ func NewAPIClient(cfg *Config) *apiv1.APIClient {
 	if cfg.HTTPClient != nil {
 		apiCfg.HTTPClient = cfg.HTTPClient
 	}
-	if cfg.ServerURL != nil {
-		apiCfg.Host = cfg.ServerURL.Host
-		apiCfg.Scheme = cfg.ServerURL.Scheme
+	if cfg.BaseURL != "" {
+		apiCfg.Servers = []apiv1.ServerConfiguration{
+			{
+				URL: cfg.BaseURL,
+			},
+		}
 	}
 
 	apiCfg.Debug = cfg.Debug

--- a/serviceregistrymgmt/apiv1/README.md
+++ b/serviceregistrymgmt/apiv1/README.md
@@ -39,11 +39,10 @@ registries, resp, err := client.DefaultApi.GetRegistries(context.Background()).E
 You can override the default configuration options:
 
 ```go
-baseURL, _ := url.Parse("http://localhost:8001")
 cfg := serviceregistrymgmt.Config{
     HTTPClient: yourHTTPClient,
     Debug: true,
-    ServerURL: baseURL,
+    BaseURL: "http://localhost:8080",
 }
 
 client := serviceregistrymgmt.NewAPIClient(&cfg)

--- a/serviceregistrymgmt/apiv1/client.go
+++ b/serviceregistrymgmt/apiv1/client.go
@@ -21,9 +21,12 @@ func NewAPIClient(cfg *Config) *apiClient.APIClient {
 	if cfg.HTTPClient != nil {
 		apiCfg.HTTPClient = cfg.HTTPClient
 	}
-	if cfg.ServerURL != nil {
-		apiCfg.Host = cfg.ServerURL.Host
-		apiCfg.Scheme = cfg.ServerURL.Scheme
+	if cfg.BaseURL != "" {
+		apiCfg.Servers = []apiClient.ServerConfiguration{
+			{
+				URL: cfg.BaseURL,
+			},
+		}
 	}
 
 	apiCfg.Debug = cfg.Debug


### PR DESCRIPTION
Instead of setting the generated config values of `Host` and `Scheme`, this change instead overrides the `ServerURL` configuration. The reason for this is because setting `Host` strips out the path path.

So if I were to set `cfg.Host = "http://locahost:8080/rest` then `/rest` would not be included in the API requests.

```go
client := kafkamgmt.NewAPIClient(&kafkamgmt.Config{
	BaseURL: "http://localhost:8080/rest"
})
```