### PR TITLE
ci: revert to use old Bash scripts on main

### DIFF
--- a/.github/workflows/generate_api_client.yaml
+++ b/.github/workflows/generate_api_client.yaml
@@ -1,4 +1,3 @@
-
 name: Generate API client
 on:
   repository_dispatch:
@@ -7,27 +6,26 @@ on:
 jobs:
   generate_client:
     env:
-      GOPATH: /home/runner/work/app-services-sdk-go/go
+      APP_SERVICES_TOKEN: "${{ secrets.CI_USER_TOKEN }}"
+      BF2_TOKEN: "${{ secrets.BF2_TOKEN }}"
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Fetch OpenAPI schema
-        run: |
-          export PATH=${PATH}:`go env GOPATH`/bin
-
-          # fetch API spec
-          go get -u github.com/redhat-developer/app-services-sdk-go/internal/apigen/cmd/api-fetch@main
-          api-fetch --download-url=${{ github.event.client_payload.download_url }} --token=${{ secrets.BF2_TOKEN }}
-          
-          # generate API client
-          go get -u github.com/redhat-developer/app-services-sdk-go/internal/apigen/cmd/api-generate@main
-          api-generate --client-id=${{ github.event.client_payload.id }} --download-url=${{ github.event.client_payload.download_url}} --generator=go --templates-dir="./scripts/templates" --repo-metadata ".config/api-client-metadata.json"
-        
-          # create Pull Request
-          go get -u github.com/redhat-developer/app-services-sdk-go/internal/apigen/cmd/api-create-pr@main
-          go mod tidy
-          api-create-pr --repo-metadata ".config/api-client-metadata.json" --client-id=${{ github.event.client_payload.id }} --token=${{ secrets.CI_USER_TOKEN }} --author="app-services-ci" --owner="redhat-developer" --repo="app-services-sdk-go"
+          go-version: 1.13
+      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v2
+      - run: ./scripts/fetch_api.sh ${{ github.event.client_payload.download_url }}
+      - run: ./scripts/generate_go.sh ${{ github.event.client_payload.id }} ${{ github.event.client_payload.download_url }}
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          title: "chore: re-generate API client"
+          token: "${{ env.APP_SERVICES_TOKEN }}"
+          commit-message: "chore: generate new API client"
+          author: "app-services-ci <app-services-ci@users.noreply.github.com>"
+          delete-branch: true
+          reviewers: "craicoverflow, wtrocki"
+          body: |
+            _ :robot: This pull request was generated_
+            Generate a new API client


### PR DESCRIPTION
Had some issues with using the Go tooling on GitHub Actions. Would like to revisit and improve them in the future.