### PR TITLE
chore: include a diff of the OpenAPI file changes in the PR description

### DIFF
--- a/.github/workflows/update_openapi.yaml
+++ b/.github/workflows/update_openapi.yaml
@@ -14,6 +14,18 @@ jobs:
           go-version: 1.16
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set client metadata
+        id: set_config
+        run: |
+          content=$(cat .config/api-client-metadata.json)
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          echo "::set-output name=client_config::$content"
+      - name: Set OpenAPI file path
+        id: set_filepath
+        run: |
+          echo "::set-output openapi_file::${{fromJson(steps.set_config.outputs.client_config)[${{ github.event.client_payload.id }}].openapi_file}}"
       - name: Fetch OpenAPI schema
         run: |
           export PATH=${PATH}:`go env GOPATH`/bin
@@ -23,23 +35,45 @@ jobs:
           api-fetch --download-url=${{ github.event.client_payload.download_url }} --download-location=".openapi" --token=${{ secrets.BF2_TOKEN }}
           go mod tidy
 
+      - name: Generate OpenAPI diff
+        id: generate_openapi_diff
+        run: |
+          # get the current OpenAPI file to use as the base when comparing
+          git show main:${{ steps.set_filepath.outputs.openapi_file }} > .openapi/tmp-oas
+
+          export PATH=${PATH}:`go env GOPATH`/bin
+
+          go install github.com/tufin/oasdiff:latest
+          
+          # output the diff to a var
+          echo "::set-output changelog::${{ oasdiff -base .openapi/tmp-oas -revision ${{ steps.set_filepath.outputs.openapi_file }} -format text }}"
+
+          rm -rf .openapi/tmp-oas
+      
       - uses: peter-evans/create-pull-request@v3
         with:
           title: "chore(openapi): update ${{ github.event.client_payload.id }} OpenAPI document"
           token: "${{ secrets.CI_USER_TOKEN }}"
-          commit-message: "chore(openapi): update ${{ github.event.client_payload.id }} OpenAPI document"
+          commit-message: >
+            chore(openapi): update ${{ github.event.client_payload.id }} OpenAPI document
+
+            ${{ steps.generate_openapi_diff.outputs.changelog }}
           author: "app-services-ci <app-services-ci@users.noreply.github.com>"
           branch: chore/add-${{ github.event.client_payload.id }}-openapi
           branch-suffix: timestamp
           reviewers: craicoverflow, wtrocki
           delete-branch: true
-          body: |
+          body: >
             _This pull request was auto-generated_
 
             This PR adds the latest version OpenAPI document version for **${{ github.event.client_payload.id }}**.
 
-            **Actions**:
+            ## Actions:
 
-                1. Review changes on the OpenAPI file and validate if it is correct
+                1. Review changes on the OpenAPI file and validate if it is correct.
                 2. Perform manual changes if needed or apply local patches for the OpenAPI files.
                 3. Merge this pull request only when the API has been released.
+
+            ## Changes
+
+            ${{ steps.generate_openapi_diff.outputs.changelog }}

--- a/scripts/generate_go.sh
+++ b/scripts/generate_go.sh
@@ -1,4 +1,4 @@
-# #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # set output path of the API client
 CLIENT_ID=$1


### PR DESCRIPTION
The idea here is that the generated pull request will contain a diff of the OpenAPI changes. This will make it easier for the reviewer to review and will hopefully give better release notes.

There is no way to test if this will 100% work on GitHub Actions - it may not work.

This uses https://github.com/Tufin/oasdiff to generate a diff.