### PR TITLE
fix(registry-instances)!: do not automatically parse date formats due to invalid format on backend

### DIFF
--- a/.openapi/registry-instance.json
+++ b/.openapi/registry-instance.json
@@ -2241,7 +2241,7 @@
             "type": "string"
           },
           "createdOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "type": "string"
           },
           "type": {
@@ -2477,7 +2477,7 @@
             "type": "string"
           },
           "createdOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "description": "",
             "type": "string"
           },
@@ -2632,7 +2632,7 @@
             "type": "string"
           },
           "createdOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "description": "",
             "type": "string"
           },
@@ -2656,7 +2656,7 @@
             "description": ""
           },
           "modifiedOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "description": "",
             "type": "string"
           },
@@ -2712,14 +2712,14 @@
             "type": "string"
           },
           "createdOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "type": "string"
           },
           "modifiedBy": {
             "type": "string"
           },
           "modifiedOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "type": "string"
           },
           "id": {
@@ -2881,7 +2881,7 @@
             "type": "string"
           },
           "builtOn": {
-            "format": "date-time",
+            "format": "utc-date",
             "type": "string"
           }
         },

--- a/registryinstance/apiv1internal/client/api/openapi.yaml
+++ b/registryinstance/apiv1internal/client/api/openapi.yaml
@@ -3424,7 +3424,7 @@ components:
         createdBy:
           type: string
         createdOn:
-          format: date-time
+          format: utc-date
           type: string
         type:
           $ref: '#/components/schemas/ArtifactType'
@@ -3666,7 +3666,7 @@ components:
         description:
           type: string
         createdOn:
-          format: date-time
+          format: utc-date
           type: string
         createdBy:
           type: string
@@ -3771,7 +3771,7 @@ components:
         description:
           type: string
         createdOn:
-          format: date-time
+          format: utc-date
           type: string
         createdBy:
           type: string
@@ -3784,7 +3784,7 @@ components:
         state:
           $ref: '#/components/schemas/ArtifactState'
         modifiedOn:
-          format: date-time
+          format: utc-date
           type: string
         modifiedBy:
           type: string
@@ -3828,12 +3828,12 @@ components:
         createdBy:
           type: string
         createdOn:
-          format: date-time
+          format: utc-date
           type: string
         modifiedBy:
           type: string
         modifiedOn:
-          format: date-time
+          format: utc-date
           type: string
         id:
           description: The ID of a single artifact.
@@ -3941,7 +3941,7 @@ components:
         version:
           type: string
         builtOn:
-          format: date-time
+          format: utc-date
           type: string
       title: Root Type for SystemInfo
       type: object

--- a/registryinstance/apiv1internal/client/docs/ArtifactMetaData.md
+++ b/registryinstance/apiv1internal/client/docs/ArtifactMetaData.md
@@ -7,9 +7,9 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
 **CreatedBy** | **string** |  | 
-**CreatedOn** | **time.Time** |  | 
+**CreatedOn** | **string** |  | 
 **ModifiedBy** | **string** |  | 
-**ModifiedOn** | **time.Time** |  | 
+**ModifiedOn** | **string** |  | 
 **Id** | **string** | The ID of a single artifact. | 
 **Version** | **string** |  | 
 **Type** | [**ArtifactType**](ArtifactType.md) |  | 
@@ -25,7 +25,7 @@ Name | Type | Description | Notes
 
 ### NewArtifactMetaData
 
-`func NewArtifactMetaData(createdBy string, createdOn time.Time, modifiedBy string, modifiedOn time.Time, id string, version string, type_ ArtifactType, globalId int64, state ArtifactState, contentId int64, ) *ArtifactMetaData`
+`func NewArtifactMetaData(createdBy string, createdOn string, modifiedBy string, modifiedOn string, id string, version string, type_ ArtifactType, globalId int64, state ArtifactState, contentId int64, ) *ArtifactMetaData`
 
 NewArtifactMetaData instantiates a new ArtifactMetaData object
 This constructor will assign default values to properties that have it defined,
@@ -116,20 +116,20 @@ SetCreatedBy sets CreatedBy field to given value.
 
 ### GetCreatedOn
 
-`func (o *ArtifactMetaData) GetCreatedOn() time.Time`
+`func (o *ArtifactMetaData) GetCreatedOn() string`
 
 GetCreatedOn returns the CreatedOn field if non-nil, zero value otherwise.
 
 ### GetCreatedOnOk
 
-`func (o *ArtifactMetaData) GetCreatedOnOk() (*time.Time, bool)`
+`func (o *ArtifactMetaData) GetCreatedOnOk() (*string, bool)`
 
 GetCreatedOnOk returns a tuple with the CreatedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCreatedOn
 
-`func (o *ArtifactMetaData) SetCreatedOn(v time.Time)`
+`func (o *ArtifactMetaData) SetCreatedOn(v string)`
 
 SetCreatedOn sets CreatedOn field to given value.
 
@@ -158,20 +158,20 @@ SetModifiedBy sets ModifiedBy field to given value.
 
 ### GetModifiedOn
 
-`func (o *ArtifactMetaData) GetModifiedOn() time.Time`
+`func (o *ArtifactMetaData) GetModifiedOn() string`
 
 GetModifiedOn returns the ModifiedOn field if non-nil, zero value otherwise.
 
 ### GetModifiedOnOk
 
-`func (o *ArtifactMetaData) GetModifiedOnOk() (*time.Time, bool)`
+`func (o *ArtifactMetaData) GetModifiedOnOk() (*string, bool)`
 
 GetModifiedOnOk returns a tuple with the ModifiedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetModifiedOn
 
-`func (o *ArtifactMetaData) SetModifiedOn(v time.Time)`
+`func (o *ArtifactMetaData) SetModifiedOn(v string)`
 
 SetModifiedOn sets ModifiedOn field to given value.
 

--- a/registryinstance/apiv1internal/client/docs/SearchedArtifact.md
+++ b/registryinstance/apiv1internal/client/docs/SearchedArtifact.md
@@ -7,12 +7,12 @@ Name | Type | Description | Notes
 **Id** | **string** | The ID of a single artifact. | 
 **Name** | Pointer to **string** |  | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
-**CreatedOn** | **time.Time** |  | 
+**CreatedOn** | **string** |  | 
 **CreatedBy** | **string** |  | 
 **Type** | [**ArtifactType**](ArtifactType.md) |  | 
 **Labels** | Pointer to **[]string** |  | [optional] 
 **State** | [**ArtifactState**](ArtifactState.md) |  | 
-**ModifiedOn** | Pointer to **time.Time** |  | [optional] 
+**ModifiedOn** | Pointer to **string** |  | [optional] 
 **ModifiedBy** | Pointer to **string** |  | [optional] 
 **GroupId** | Pointer to **string** | An ID of a single artifact group. | [optional] 
 
@@ -21,7 +21,7 @@ Name | Type | Description | Notes
 
 ### NewSearchedArtifact
 
-`func NewSearchedArtifact(id string, createdOn time.Time, createdBy string, type_ ArtifactType, state ArtifactState, ) *SearchedArtifact`
+`func NewSearchedArtifact(id string, createdOn string, createdBy string, type_ ArtifactType, state ArtifactState, ) *SearchedArtifact`
 
 NewSearchedArtifact instantiates a new SearchedArtifact object
 This constructor will assign default values to properties that have it defined,
@@ -112,20 +112,20 @@ HasDescription returns a boolean if a field has been set.
 
 ### GetCreatedOn
 
-`func (o *SearchedArtifact) GetCreatedOn() time.Time`
+`func (o *SearchedArtifact) GetCreatedOn() string`
 
 GetCreatedOn returns the CreatedOn field if non-nil, zero value otherwise.
 
 ### GetCreatedOnOk
 
-`func (o *SearchedArtifact) GetCreatedOnOk() (*time.Time, bool)`
+`func (o *SearchedArtifact) GetCreatedOnOk() (*string, bool)`
 
 GetCreatedOnOk returns a tuple with the CreatedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCreatedOn
 
-`func (o *SearchedArtifact) SetCreatedOn(v time.Time)`
+`func (o *SearchedArtifact) SetCreatedOn(v string)`
 
 SetCreatedOn sets CreatedOn field to given value.
 
@@ -222,20 +222,20 @@ SetState sets State field to given value.
 
 ### GetModifiedOn
 
-`func (o *SearchedArtifact) GetModifiedOn() time.Time`
+`func (o *SearchedArtifact) GetModifiedOn() string`
 
 GetModifiedOn returns the ModifiedOn field if non-nil, zero value otherwise.
 
 ### GetModifiedOnOk
 
-`func (o *SearchedArtifact) GetModifiedOnOk() (*time.Time, bool)`
+`func (o *SearchedArtifact) GetModifiedOnOk() (*string, bool)`
 
 GetModifiedOnOk returns a tuple with the ModifiedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetModifiedOn
 
-`func (o *SearchedArtifact) SetModifiedOn(v time.Time)`
+`func (o *SearchedArtifact) SetModifiedOn(v string)`
 
 SetModifiedOn sets ModifiedOn field to given value.
 

--- a/registryinstance/apiv1internal/client/docs/SearchedVersion.md
+++ b/registryinstance/apiv1internal/client/docs/SearchedVersion.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **string** |  | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
-**CreatedOn** | **time.Time** |  | 
+**CreatedOn** | **string** |  | 
 **CreatedBy** | **string** |  | 
 **Type** | [**ArtifactType**](ArtifactType.md) |  | 
 **Labels** | Pointer to **[]string** |  | [optional] 
@@ -21,7 +21,7 @@ Name | Type | Description | Notes
 
 ### NewSearchedVersion
 
-`func NewSearchedVersion(createdOn time.Time, createdBy string, type_ ArtifactType, state ArtifactState, globalId int64, version string, contentId int64, ) *SearchedVersion`
+`func NewSearchedVersion(createdOn string, createdBy string, type_ ArtifactType, state ArtifactState, globalId int64, version string, contentId int64, ) *SearchedVersion`
 
 NewSearchedVersion instantiates a new SearchedVersion object
 This constructor will assign default values to properties that have it defined,
@@ -91,20 +91,20 @@ HasDescription returns a boolean if a field has been set.
 
 ### GetCreatedOn
 
-`func (o *SearchedVersion) GetCreatedOn() time.Time`
+`func (o *SearchedVersion) GetCreatedOn() string`
 
 GetCreatedOn returns the CreatedOn field if non-nil, zero value otherwise.
 
 ### GetCreatedOnOk
 
-`func (o *SearchedVersion) GetCreatedOnOk() (*time.Time, bool)`
+`func (o *SearchedVersion) GetCreatedOnOk() (*string, bool)`
 
 GetCreatedOnOk returns a tuple with the CreatedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCreatedOn
 
-`func (o *SearchedVersion) SetCreatedOn(v time.Time)`
+`func (o *SearchedVersion) SetCreatedOn(v string)`
 
 SetCreatedOn sets CreatedOn field to given value.
 

--- a/registryinstance/apiv1internal/client/docs/SystemInfo.md
+++ b/registryinstance/apiv1internal/client/docs/SystemInfo.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
 **Version** | Pointer to **string** |  | [optional] 
-**BuiltOn** | Pointer to **time.Time** |  | [optional] 
+**BuiltOn** | Pointer to **string** |  | [optional] 
 
 
 ## Methods
@@ -110,20 +110,20 @@ HasVersion returns a boolean if a field has been set.
 
 ### GetBuiltOn
 
-`func (o *SystemInfo) GetBuiltOn() time.Time`
+`func (o *SystemInfo) GetBuiltOn() string`
 
 GetBuiltOn returns the BuiltOn field if non-nil, zero value otherwise.
 
 ### GetBuiltOnOk
 
-`func (o *SystemInfo) GetBuiltOnOk() (*time.Time, bool)`
+`func (o *SystemInfo) GetBuiltOnOk() (*string, bool)`
 
 GetBuiltOnOk returns a tuple with the BuiltOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetBuiltOn
 
-`func (o *SystemInfo) SetBuiltOn(v time.Time)`
+`func (o *SystemInfo) SetBuiltOn(v string)`
 
 SetBuiltOn sets BuiltOn field to given value.
 

--- a/registryinstance/apiv1internal/client/docs/VersionMetaData.md
+++ b/registryinstance/apiv1internal/client/docs/VersionMetaData.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
 **CreatedBy** | **string** |  | 
-**CreatedOn** | **time.Time** |  | 
+**CreatedOn** | **string** |  | 
 **Type** | [**ArtifactType**](ArtifactType.md) |  | 
 **GlobalId** | **int64** |  | 
 **State** | Pointer to [**ArtifactState**](ArtifactState.md) |  | [optional] 
@@ -23,7 +23,7 @@ Name | Type | Description | Notes
 
 ### NewVersionMetaData
 
-`func NewVersionMetaData(version string, createdBy string, createdOn time.Time, type_ ArtifactType, globalId int64, id string, contentId int64, ) *VersionMetaData`
+`func NewVersionMetaData(version string, createdBy string, createdOn string, type_ ArtifactType, globalId int64, id string, contentId int64, ) *VersionMetaData`
 
 NewVersionMetaData instantiates a new VersionMetaData object
 This constructor will assign default values to properties that have it defined,
@@ -135,20 +135,20 @@ SetCreatedBy sets CreatedBy field to given value.
 
 ### GetCreatedOn
 
-`func (o *VersionMetaData) GetCreatedOn() time.Time`
+`func (o *VersionMetaData) GetCreatedOn() string`
 
 GetCreatedOn returns the CreatedOn field if non-nil, zero value otherwise.
 
 ### GetCreatedOnOk
 
-`func (o *VersionMetaData) GetCreatedOnOk() (*time.Time, bool)`
+`func (o *VersionMetaData) GetCreatedOnOk() (*string, bool)`
 
 GetCreatedOnOk returns a tuple with the CreatedOn field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCreatedOn
 
-`func (o *VersionMetaData) SetCreatedOn(v time.Time)`
+`func (o *VersionMetaData) SetCreatedOn(v string)`
 
 SetCreatedOn sets CreatedOn field to given value.
 

--- a/registryinstance/apiv1internal/client/model_artifact_meta_data.go
+++ b/registryinstance/apiv1internal/client/model_artifact_meta_data.go
@@ -1,7 +1,7 @@
 /*
  * Apicurio Registry API [v2]
  *
- * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`.
+ * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`. 
  *
  * API version: 2.1.0-SNAPSHOT
  * Contact: apicurio@lists.jboss.org
@@ -13,22 +13,22 @@ package registryinstanceclient
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // ArtifactMetaData struct for ArtifactMetaData
 type ArtifactMetaData struct {
+
 	Name *string `json:"name,omitempty"`
 
 	Description *string `json:"description,omitempty"`
 
 	CreatedBy string `json:"createdBy"`
 
-	CreatedOn time.Time `json:"-"`
+	CreatedOn string `json:"createdOn"`
 
 	ModifiedBy string `json:"modifiedBy"`
 
-	ModifiedOn time.Time `json:"-"`
+	ModifiedOn string `json:"modifiedOn"`
 
 	// The ID of a single artifact.
 	Id string `json:"id"`
@@ -50,13 +50,14 @@ type ArtifactMetaData struct {
 	GroupId *string `json:"groupId,omitempty"`
 
 	ContentId int64 `json:"contentId"`
+
 }
 
 // NewArtifactMetaData instantiates a new ArtifactMetaData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewArtifactMetaData(createdBy string, createdOn time.Time, modifiedBy string, modifiedOn time.Time, id string, version string, type_ ArtifactType, globalId int64, state ArtifactState, contentId int64) *ArtifactMetaData {
+func NewArtifactMetaData(createdBy string, createdOn string, modifiedBy string, modifiedOn string, id string, version string, type_ ArtifactType, globalId int64, state ArtifactState, contentId int64) *ArtifactMetaData {
 	this := ArtifactMetaData{}
 	this.CreatedBy = createdBy
 	this.CreatedOn = createdOn
@@ -77,8 +78,24 @@ func NewArtifactMetaData(createdBy string, createdOn time.Time, modifiedBy strin
 func NewArtifactMetaDataWithDefaults() *ArtifactMetaData {
 	this := ArtifactMetaData{}
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 	return &this
 }
+
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *ArtifactMetaData) GetName() string {
@@ -112,6 +129,7 @@ func (o *ArtifactMetaData) SetName(v string) {
 	o.Name = &v
 }
 
+
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *ArtifactMetaData) GetDescription() string {
 	if o == nil || o.Description == nil {
@@ -144,6 +162,7 @@ func (o *ArtifactMetaData) SetDescription(v string) {
 	o.Description = &v
 }
 
+
 // GetCreatedBy returns the CreatedBy field value
 func (o *ArtifactMetaData) GetCreatedBy() string {
 	if o == nil {
@@ -157,7 +176,7 @@ func (o *ArtifactMetaData) GetCreatedBy() string {
 // GetCreatedByOk returns a tuple with the CreatedBy field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetCreatedByOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedBy, true
@@ -168,10 +187,11 @@ func (o *ArtifactMetaData) SetCreatedBy(v string) {
 	o.CreatedBy = v
 }
 
+
 // GetCreatedOn returns the CreatedOn field value
-func (o *ArtifactMetaData) GetCreatedOn() time.Time {
+func (o *ArtifactMetaData) GetCreatedOn() string {
 	if o == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 
@@ -180,17 +200,18 @@ func (o *ArtifactMetaData) GetCreatedOn() time.Time {
 
 // GetCreatedOnOk returns a tuple with the CreatedOn field value
 // and a boolean to check if the value has been set.
-func (o *ArtifactMetaData) GetCreatedOnOk() (*time.Time, bool) {
-	if o == nil {
+func (o *ArtifactMetaData) GetCreatedOnOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedOn, true
 }
 
 // SetCreatedOn sets field value
-func (o *ArtifactMetaData) SetCreatedOn(v time.Time) {
+func (o *ArtifactMetaData) SetCreatedOn(v string) {
 	o.CreatedOn = v
 }
+
 
 // GetModifiedBy returns the ModifiedBy field value
 func (o *ArtifactMetaData) GetModifiedBy() string {
@@ -205,7 +226,7 @@ func (o *ArtifactMetaData) GetModifiedBy() string {
 // GetModifiedByOk returns a tuple with the ModifiedBy field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetModifiedByOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ModifiedBy, true
@@ -216,10 +237,11 @@ func (o *ArtifactMetaData) SetModifiedBy(v string) {
 	o.ModifiedBy = v
 }
 
+
 // GetModifiedOn returns the ModifiedOn field value
-func (o *ArtifactMetaData) GetModifiedOn() time.Time {
+func (o *ArtifactMetaData) GetModifiedOn() string {
 	if o == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 
@@ -228,17 +250,18 @@ func (o *ArtifactMetaData) GetModifiedOn() time.Time {
 
 // GetModifiedOnOk returns a tuple with the ModifiedOn field value
 // and a boolean to check if the value has been set.
-func (o *ArtifactMetaData) GetModifiedOnOk() (*time.Time, bool) {
-	if o == nil {
+func (o *ArtifactMetaData) GetModifiedOnOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ModifiedOn, true
 }
 
 // SetModifiedOn sets field value
-func (o *ArtifactMetaData) SetModifiedOn(v time.Time) {
+func (o *ArtifactMetaData) SetModifiedOn(v string) {
 	o.ModifiedOn = v
 }
+
 
 // GetId returns the Id field value
 func (o *ArtifactMetaData) GetId() string {
@@ -253,7 +276,7 @@ func (o *ArtifactMetaData) GetId() string {
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetIdOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Id, true
@@ -263,6 +286,7 @@ func (o *ArtifactMetaData) GetIdOk() (*string, bool) {
 func (o *ArtifactMetaData) SetId(v string) {
 	o.Id = v
 }
+
 
 // GetVersion returns the Version field value
 func (o *ArtifactMetaData) GetVersion() string {
@@ -277,7 +301,7 @@ func (o *ArtifactMetaData) GetVersion() string {
 // GetVersionOk returns a tuple with the Version field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetVersionOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Version, true
@@ -287,6 +311,7 @@ func (o *ArtifactMetaData) GetVersionOk() (*string, bool) {
 func (o *ArtifactMetaData) SetVersion(v string) {
 	o.Version = v
 }
+
 
 // GetType returns the Type field value
 func (o *ArtifactMetaData) GetType() ArtifactType {
@@ -301,7 +326,7 @@ func (o *ArtifactMetaData) GetType() ArtifactType {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetTypeOk() (*ArtifactType, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -311,6 +336,7 @@ func (o *ArtifactMetaData) GetTypeOk() (*ArtifactType, bool) {
 func (o *ArtifactMetaData) SetType(v ArtifactType) {
 	o.Type = v
 }
+
 
 // GetGlobalId returns the GlobalId field value
 func (o *ArtifactMetaData) GetGlobalId() int64 {
@@ -325,7 +351,7 @@ func (o *ArtifactMetaData) GetGlobalId() int64 {
 // GetGlobalIdOk returns a tuple with the GlobalId field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetGlobalIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.GlobalId, true
@@ -335,6 +361,7 @@ func (o *ArtifactMetaData) GetGlobalIdOk() (*int64, bool) {
 func (o *ArtifactMetaData) SetGlobalId(v int64) {
 	o.GlobalId = v
 }
+
 
 // GetState returns the State field value
 func (o *ArtifactMetaData) GetState() ArtifactState {
@@ -349,7 +376,7 @@ func (o *ArtifactMetaData) GetState() ArtifactState {
 // GetStateOk returns a tuple with the State field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetStateOk() (*ArtifactState, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.State, true
@@ -359,6 +386,7 @@ func (o *ArtifactMetaData) GetStateOk() (*ArtifactState, bool) {
 func (o *ArtifactMetaData) SetState(v ArtifactState) {
 	o.State = v
 }
+
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
 func (o *ArtifactMetaData) GetLabels() []string {
@@ -392,6 +420,7 @@ func (o *ArtifactMetaData) SetLabels(v []string) {
 	o.Labels = &v
 }
 
+
 // GetProperties returns the Properties field value if set, zero value otherwise.
 func (o *ArtifactMetaData) GetProperties() map[string]string {
 	if o == nil || o.Properties == nil {
@@ -423,6 +452,7 @@ func (o *ArtifactMetaData) HasProperties() bool {
 func (o *ArtifactMetaData) SetProperties(v map[string]string) {
 	o.Properties = &v
 }
+
 
 // GetGroupId returns the GroupId field value if set, zero value otherwise.
 func (o *ArtifactMetaData) GetGroupId() string {
@@ -456,6 +486,7 @@ func (o *ArtifactMetaData) SetGroupId(v string) {
 	o.GroupId = &v
 }
 
+
 // GetContentId returns the ContentId field value
 func (o *ArtifactMetaData) GetContentId() int64 {
 	if o == nil {
@@ -469,7 +500,7 @@ func (o *ArtifactMetaData) GetContentId() int64 {
 // GetContentIdOk returns a tuple with the ContentId field value
 // and a boolean to check if the value has been set.
 func (o *ArtifactMetaData) GetContentIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ContentId, true
@@ -480,69 +511,70 @@ func (o *ArtifactMetaData) SetContentId(v int64) {
 	o.ContentId = v
 }
 
+
 func (o ArtifactMetaData) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-
+	
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
+    
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
 	}
-
+    
 	if true {
 		toSerialize["createdBy"] = o.CreatedBy
 	}
-
+    
 	if true {
 		toSerialize["createdOn"] = o.CreatedOn
 	}
-
+    
 	if true {
 		toSerialize["modifiedBy"] = o.ModifiedBy
 	}
-
+    
 	if true {
 		toSerialize["modifiedOn"] = o.ModifiedOn
 	}
-
+    
 	if true {
 		toSerialize["id"] = o.Id
 	}
-
+    
 	if true {
 		toSerialize["version"] = o.Version
 	}
-
+    
 	if true {
 		toSerialize["type"] = o.Type
 	}
-
+    
 	if true {
 		toSerialize["globalId"] = o.GlobalId
 	}
-
+    
 	if true {
 		toSerialize["state"] = o.State
 	}
-
+    
 	if o.Labels != nil {
 		toSerialize["labels"] = o.Labels
 	}
-
+    
 	if o.Properties != nil {
 		toSerialize["properties"] = o.Properties
 	}
-
+    
 	if o.GroupId != nil {
 		toSerialize["groupId"] = o.GroupId
 	}
-
+    
 	if true {
 		toSerialize["contentId"] = o.ContentId
 	}
-
+    
 	return json.Marshal(toSerialize)
 }
 
@@ -581,3 +613,4 @@ func (v *NullableArtifactMetaData) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/registryinstance/apiv1internal/client/model_searched_artifact.go
+++ b/registryinstance/apiv1internal/client/model_searched_artifact.go
@@ -1,7 +1,7 @@
 /*
  * Apicurio Registry API [v2]
  *
- * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`.
+ * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`. 
  *
  * API version: 2.1.0-SNAPSHOT
  * Contact: apicurio@lists.jboss.org
@@ -13,7 +13,6 @@ package registryinstanceclient
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // SearchedArtifact Models a single artifact from the result set returned when searching for artifacts.
@@ -26,7 +25,7 @@ type SearchedArtifact struct {
 
 	Description *string `json:"description,omitempty"`
 
-	CreatedOn time.Time `json:"-"`
+	CreatedOn string `json:"createdOn"`
 
 	CreatedBy string `json:"createdBy"`
 
@@ -36,19 +35,20 @@ type SearchedArtifact struct {
 
 	State ArtifactState `json:"state"`
 
-	ModifiedOn *time.Time `json:"-"`
+	ModifiedOn *string `json:"modifiedOn,omitempty"`
 
 	ModifiedBy *string `json:"modifiedBy,omitempty"`
 
 	// An ID of a single artifact group.
 	GroupId *string `json:"groupId,omitempty"`
+
 }
 
 // NewSearchedArtifact instantiates a new SearchedArtifact object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSearchedArtifact(id string, createdOn time.Time, createdBy string, type_ ArtifactType, state ArtifactState) *SearchedArtifact {
+func NewSearchedArtifact(id string, createdOn string, createdBy string, type_ ArtifactType, state ArtifactState) *SearchedArtifact {
 	this := SearchedArtifact{}
 	this.Id = id
 	this.CreatedOn = createdOn
@@ -64,8 +64,20 @@ func NewSearchedArtifact(id string, createdOn time.Time, createdBy string, type_
 func NewSearchedArtifactWithDefaults() *SearchedArtifact {
 	this := SearchedArtifact{}
 
+
+
+
+
+
+
+
+
+
+
+
 	return &this
 }
+
 
 // GetId returns the Id field value
 func (o *SearchedArtifact) GetId() string {
@@ -80,7 +92,7 @@ func (o *SearchedArtifact) GetId() string {
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
 func (o *SearchedArtifact) GetIdOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Id, true
@@ -90,6 +102,7 @@ func (o *SearchedArtifact) GetIdOk() (*string, bool) {
 func (o *SearchedArtifact) SetId(v string) {
 	o.Id = v
 }
+
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *SearchedArtifact) GetName() string {
@@ -123,6 +136,7 @@ func (o *SearchedArtifact) SetName(v string) {
 	o.Name = &v
 }
 
+
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *SearchedArtifact) GetDescription() string {
 	if o == nil || o.Description == nil {
@@ -155,10 +169,11 @@ func (o *SearchedArtifact) SetDescription(v string) {
 	o.Description = &v
 }
 
+
 // GetCreatedOn returns the CreatedOn field value
-func (o *SearchedArtifact) GetCreatedOn() time.Time {
+func (o *SearchedArtifact) GetCreatedOn() string {
 	if o == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 
@@ -167,17 +182,18 @@ func (o *SearchedArtifact) GetCreatedOn() time.Time {
 
 // GetCreatedOnOk returns a tuple with the CreatedOn field value
 // and a boolean to check if the value has been set.
-func (o *SearchedArtifact) GetCreatedOnOk() (*time.Time, bool) {
-	if o == nil {
+func (o *SearchedArtifact) GetCreatedOnOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedOn, true
 }
 
 // SetCreatedOn sets field value
-func (o *SearchedArtifact) SetCreatedOn(v time.Time) {
+func (o *SearchedArtifact) SetCreatedOn(v string) {
 	o.CreatedOn = v
 }
+
 
 // GetCreatedBy returns the CreatedBy field value
 func (o *SearchedArtifact) GetCreatedBy() string {
@@ -192,7 +208,7 @@ func (o *SearchedArtifact) GetCreatedBy() string {
 // GetCreatedByOk returns a tuple with the CreatedBy field value
 // and a boolean to check if the value has been set.
 func (o *SearchedArtifact) GetCreatedByOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedBy, true
@@ -202,6 +218,7 @@ func (o *SearchedArtifact) GetCreatedByOk() (*string, bool) {
 func (o *SearchedArtifact) SetCreatedBy(v string) {
 	o.CreatedBy = v
 }
+
 
 // GetType returns the Type field value
 func (o *SearchedArtifact) GetType() ArtifactType {
@@ -216,7 +233,7 @@ func (o *SearchedArtifact) GetType() ArtifactType {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *SearchedArtifact) GetTypeOk() (*ArtifactType, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -226,6 +243,7 @@ func (o *SearchedArtifact) GetTypeOk() (*ArtifactType, bool) {
 func (o *SearchedArtifact) SetType(v ArtifactType) {
 	o.Type = v
 }
+
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
 func (o *SearchedArtifact) GetLabels() []string {
@@ -259,6 +277,7 @@ func (o *SearchedArtifact) SetLabels(v []string) {
 	o.Labels = &v
 }
 
+
 // GetState returns the State field value
 func (o *SearchedArtifact) GetState() ArtifactState {
 	if o == nil {
@@ -272,7 +291,7 @@ func (o *SearchedArtifact) GetState() ArtifactState {
 // GetStateOk returns a tuple with the State field value
 // and a boolean to check if the value has been set.
 func (o *SearchedArtifact) GetStateOk() (*ArtifactState, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.State, true
@@ -283,10 +302,11 @@ func (o *SearchedArtifact) SetState(v ArtifactState) {
 	o.State = v
 }
 
+
 // GetModifiedOn returns the ModifiedOn field value if set, zero value otherwise.
-func (o *SearchedArtifact) GetModifiedOn() time.Time {
+func (o *SearchedArtifact) GetModifiedOn() string {
 	if o == nil || o.ModifiedOn == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ModifiedOn
@@ -294,7 +314,7 @@ func (o *SearchedArtifact) GetModifiedOn() time.Time {
 
 // GetModifiedOnOk returns a tuple with the ModifiedOn field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SearchedArtifact) GetModifiedOnOk() (*time.Time, bool) {
+func (o *SearchedArtifact) GetModifiedOnOk() (*string, bool) {
 	if o == nil || o.ModifiedOn == nil {
 		return nil, false
 	}
@@ -310,10 +330,11 @@ func (o *SearchedArtifact) HasModifiedOn() bool {
 	return false
 }
 
-// SetModifiedOn gets a reference to the given time.Time and assigns it to the ModifiedOn field.
-func (o *SearchedArtifact) SetModifiedOn(v time.Time) {
+// SetModifiedOn gets a reference to the given string and assigns it to the ModifiedOn field.
+func (o *SearchedArtifact) SetModifiedOn(v string) {
 	o.ModifiedOn = &v
 }
+
 
 // GetModifiedBy returns the ModifiedBy field value if set, zero value otherwise.
 func (o *SearchedArtifact) GetModifiedBy() string {
@@ -347,6 +368,7 @@ func (o *SearchedArtifact) SetModifiedBy(v string) {
 	o.ModifiedBy = &v
 }
 
+
 // GetGroupId returns the GroupId field value if set, zero value otherwise.
 func (o *SearchedArtifact) GetGroupId() string {
 	if o == nil || o.GroupId == nil {
@@ -379,53 +401,54 @@ func (o *SearchedArtifact) SetGroupId(v string) {
 	o.GroupId = &v
 }
 
+
 func (o SearchedArtifact) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-
+	
 	if true {
 		toSerialize["id"] = o.Id
 	}
-
+    
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
+    
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
 	}
-
+    
 	if true {
 		toSerialize["createdOn"] = o.CreatedOn
 	}
-
+    
 	if true {
 		toSerialize["createdBy"] = o.CreatedBy
 	}
-
+    
 	if true {
 		toSerialize["type"] = o.Type
 	}
-
+    
 	if o.Labels != nil {
 		toSerialize["labels"] = o.Labels
 	}
-
+    
 	if true {
 		toSerialize["state"] = o.State
 	}
-
+    
 	if o.ModifiedOn != nil {
 		toSerialize["modifiedOn"] = o.ModifiedOn
 	}
-
+    
 	if o.ModifiedBy != nil {
 		toSerialize["modifiedBy"] = o.ModifiedBy
 	}
-
+    
 	if o.GroupId != nil {
 		toSerialize["groupId"] = o.GroupId
 	}
-
+    
 	return json.Marshal(toSerialize)
 }
 
@@ -464,3 +487,4 @@ func (v *NullableSearchedArtifact) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/registryinstance/apiv1internal/client/model_searched_version.go
+++ b/registryinstance/apiv1internal/client/model_searched_version.go
@@ -1,7 +1,7 @@
 /*
  * Apicurio Registry API [v2]
  *
- * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`.
+ * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`. 
  *
  * API version: 2.1.0-SNAPSHOT
  * Contact: apicurio@lists.jboss.org
@@ -13,16 +13,16 @@ package registryinstanceclient
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // SearchedVersion Models a single artifact from the result set returned when searching for artifacts.
 type SearchedVersion struct {
+
 	Name *string `json:"name,omitempty"`
 
 	Description *string `json:"description,omitempty"`
 
-	CreatedOn time.Time `json:"-"`
+	CreatedOn string `json:"createdOn"`
 
 	CreatedBy string `json:"createdBy"`
 
@@ -40,13 +40,14 @@ type SearchedVersion struct {
 	Properties *map[string]string `json:"properties,omitempty"`
 
 	ContentId int64 `json:"contentId"`
+
 }
 
 // NewSearchedVersion instantiates a new SearchedVersion object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSearchedVersion(createdOn time.Time, createdBy string, type_ ArtifactType, state ArtifactState, globalId int64, version string, contentId int64) *SearchedVersion {
+func NewSearchedVersion(createdOn string, createdBy string, type_ ArtifactType, state ArtifactState, globalId int64, version string, contentId int64) *SearchedVersion {
 	this := SearchedVersion{}
 	this.CreatedOn = createdOn
 	this.CreatedBy = createdBy
@@ -64,8 +65,20 @@ func NewSearchedVersion(createdOn time.Time, createdBy string, type_ ArtifactTyp
 func NewSearchedVersionWithDefaults() *SearchedVersion {
 	this := SearchedVersion{}
 
+
+
+
+
+
+
+
+
+
+
+
 	return &this
 }
+
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *SearchedVersion) GetName() string {
@@ -99,6 +112,7 @@ func (o *SearchedVersion) SetName(v string) {
 	o.Name = &v
 }
 
+
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *SearchedVersion) GetDescription() string {
 	if o == nil || o.Description == nil {
@@ -131,10 +145,11 @@ func (o *SearchedVersion) SetDescription(v string) {
 	o.Description = &v
 }
 
+
 // GetCreatedOn returns the CreatedOn field value
-func (o *SearchedVersion) GetCreatedOn() time.Time {
+func (o *SearchedVersion) GetCreatedOn() string {
 	if o == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 
@@ -143,17 +158,18 @@ func (o *SearchedVersion) GetCreatedOn() time.Time {
 
 // GetCreatedOnOk returns a tuple with the CreatedOn field value
 // and a boolean to check if the value has been set.
-func (o *SearchedVersion) GetCreatedOnOk() (*time.Time, bool) {
-	if o == nil {
+func (o *SearchedVersion) GetCreatedOnOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedOn, true
 }
 
 // SetCreatedOn sets field value
-func (o *SearchedVersion) SetCreatedOn(v time.Time) {
+func (o *SearchedVersion) SetCreatedOn(v string) {
 	o.CreatedOn = v
 }
+
 
 // GetCreatedBy returns the CreatedBy field value
 func (o *SearchedVersion) GetCreatedBy() string {
@@ -168,7 +184,7 @@ func (o *SearchedVersion) GetCreatedBy() string {
 // GetCreatedByOk returns a tuple with the CreatedBy field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetCreatedByOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedBy, true
@@ -178,6 +194,7 @@ func (o *SearchedVersion) GetCreatedByOk() (*string, bool) {
 func (o *SearchedVersion) SetCreatedBy(v string) {
 	o.CreatedBy = v
 }
+
 
 // GetType returns the Type field value
 func (o *SearchedVersion) GetType() ArtifactType {
@@ -192,7 +209,7 @@ func (o *SearchedVersion) GetType() ArtifactType {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetTypeOk() (*ArtifactType, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -202,6 +219,7 @@ func (o *SearchedVersion) GetTypeOk() (*ArtifactType, bool) {
 func (o *SearchedVersion) SetType(v ArtifactType) {
 	o.Type = v
 }
+
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
 func (o *SearchedVersion) GetLabels() []string {
@@ -235,6 +253,7 @@ func (o *SearchedVersion) SetLabels(v []string) {
 	o.Labels = &v
 }
 
+
 // GetState returns the State field value
 func (o *SearchedVersion) GetState() ArtifactState {
 	if o == nil {
@@ -248,7 +267,7 @@ func (o *SearchedVersion) GetState() ArtifactState {
 // GetStateOk returns a tuple with the State field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetStateOk() (*ArtifactState, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.State, true
@@ -258,6 +277,7 @@ func (o *SearchedVersion) GetStateOk() (*ArtifactState, bool) {
 func (o *SearchedVersion) SetState(v ArtifactState) {
 	o.State = v
 }
+
 
 // GetGlobalId returns the GlobalId field value
 func (o *SearchedVersion) GetGlobalId() int64 {
@@ -272,7 +292,7 @@ func (o *SearchedVersion) GetGlobalId() int64 {
 // GetGlobalIdOk returns a tuple with the GlobalId field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetGlobalIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.GlobalId, true
@@ -282,6 +302,7 @@ func (o *SearchedVersion) GetGlobalIdOk() (*int64, bool) {
 func (o *SearchedVersion) SetGlobalId(v int64) {
 	o.GlobalId = v
 }
+
 
 // GetVersion returns the Version field value
 func (o *SearchedVersion) GetVersion() string {
@@ -296,7 +317,7 @@ func (o *SearchedVersion) GetVersion() string {
 // GetVersionOk returns a tuple with the Version field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetVersionOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Version, true
@@ -306,6 +327,7 @@ func (o *SearchedVersion) GetVersionOk() (*string, bool) {
 func (o *SearchedVersion) SetVersion(v string) {
 	o.Version = v
 }
+
 
 // GetProperties returns the Properties field value if set, zero value otherwise.
 func (o *SearchedVersion) GetProperties() map[string]string {
@@ -339,6 +361,7 @@ func (o *SearchedVersion) SetProperties(v map[string]string) {
 	o.Properties = &v
 }
 
+
 // GetContentId returns the ContentId field value
 func (o *SearchedVersion) GetContentId() int64 {
 	if o == nil {
@@ -352,7 +375,7 @@ func (o *SearchedVersion) GetContentId() int64 {
 // GetContentIdOk returns a tuple with the ContentId field value
 // and a boolean to check if the value has been set.
 func (o *SearchedVersion) GetContentIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ContentId, true
@@ -363,53 +386,54 @@ func (o *SearchedVersion) SetContentId(v int64) {
 	o.ContentId = v
 }
 
+
 func (o SearchedVersion) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-
+	
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
+    
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
 	}
-
+    
 	if true {
 		toSerialize["createdOn"] = o.CreatedOn
 	}
-
+    
 	if true {
 		toSerialize["createdBy"] = o.CreatedBy
 	}
-
+    
 	if true {
 		toSerialize["type"] = o.Type
 	}
-
+    
 	if o.Labels != nil {
 		toSerialize["labels"] = o.Labels
 	}
-
+    
 	if true {
 		toSerialize["state"] = o.State
 	}
-
+    
 	if true {
 		toSerialize["globalId"] = o.GlobalId
 	}
-
+    
 	if true {
 		toSerialize["version"] = o.Version
 	}
-
+    
 	if o.Properties != nil {
 		toSerialize["properties"] = o.Properties
 	}
-
+    
 	if true {
 		toSerialize["contentId"] = o.ContentId
 	}
-
+    
 	return json.Marshal(toSerialize)
 }
 
@@ -448,3 +472,4 @@ func (v *NullableSearchedVersion) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/registryinstance/apiv1internal/client/model_system_info.go
+++ b/registryinstance/apiv1internal/client/model_system_info.go
@@ -13,7 +13,6 @@ package registryinstanceclient
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // SystemInfo struct for SystemInfo
@@ -25,7 +24,7 @@ type SystemInfo struct {
 
 	Version *string `json:"version,omitempty"`
 
-	BuiltOn *time.Time `json:"builtOn,omitempty"`
+	BuiltOn *string `json:"builtOn,omitempty"`
 
 }
 
@@ -152,9 +151,9 @@ func (o *SystemInfo) SetVersion(v string) {
 
 
 // GetBuiltOn returns the BuiltOn field value if set, zero value otherwise.
-func (o *SystemInfo) GetBuiltOn() time.Time {
+func (o *SystemInfo) GetBuiltOn() string {
 	if o == nil || o.BuiltOn == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.BuiltOn
@@ -162,7 +161,7 @@ func (o *SystemInfo) GetBuiltOn() time.Time {
 
 // GetBuiltOnOk returns a tuple with the BuiltOn field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SystemInfo) GetBuiltOnOk() (*time.Time, bool) {
+func (o *SystemInfo) GetBuiltOnOk() (*string, bool) {
 	if o == nil || o.BuiltOn == nil {
 		return nil, false
 	}
@@ -178,8 +177,8 @@ func (o *SystemInfo) HasBuiltOn() bool {
 	return false
 }
 
-// SetBuiltOn gets a reference to the given time.Time and assigns it to the BuiltOn field.
-func (o *SystemInfo) SetBuiltOn(v time.Time) {
+// SetBuiltOn gets a reference to the given string and assigns it to the BuiltOn field.
+func (o *SystemInfo) SetBuiltOn(v string) {
 	o.BuiltOn = &v
 }
 

--- a/registryinstance/apiv1internal/client/model_version_meta_data.go
+++ b/registryinstance/apiv1internal/client/model_version_meta_data.go
@@ -1,7 +1,7 @@
 /*
  * Apicurio Registry API [v2]
  *
- * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`.
+ * Apicurio Registry is a datastore for standard event schemas and API designs. Apicurio Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.  The Apicurio Registry REST API enables client applications to manage the artifacts in the registry. This API provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.   The supported artifact types include: - Apache Avro schema - AsyncAPI specification - Google protocol buffers - GraphQL schema - JSON Schema - Kafka Connect schema - OpenAPI specification - Web Services Description Language - XML Schema Definition   **Important**: The Apicurio Registry REST API is available from `https://MY-REGISTRY-URL/apis/registry/v2` by default. Therefore you must prefix all API operation paths with `../apis/registry/v2` in this case. For example: `../apis/registry/v2/ids/globalIds/{globalId}`. 
  *
  * API version: 2.1.0-SNAPSHOT
  * Contact: apicurio@lists.jboss.org
@@ -13,11 +13,11 @@ package registryinstanceclient
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // VersionMetaData struct for VersionMetaData
 type VersionMetaData struct {
+
 	Version string `json:"version"`
 
 	Name *string `json:"name,omitempty"`
@@ -26,7 +26,7 @@ type VersionMetaData struct {
 
 	CreatedBy string `json:"createdBy"`
 
-	CreatedOn time.Time `json:"-"`
+	CreatedOn string `json:"createdOn"`
 
 	Type ArtifactType `json:"type"`
 
@@ -46,13 +46,14 @@ type VersionMetaData struct {
 	GroupId *string `json:"groupId,omitempty"`
 
 	ContentId int64 `json:"contentId"`
+
 }
 
 // NewVersionMetaData instantiates a new VersionMetaData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewVersionMetaData(version string, createdBy string, createdOn time.Time, type_ ArtifactType, globalId int64, id string, contentId int64) *VersionMetaData {
+func NewVersionMetaData(version string, createdBy string, createdOn string, type_ ArtifactType, globalId int64, id string, contentId int64) *VersionMetaData {
 	this := VersionMetaData{}
 	this.Version = version
 	this.CreatedBy = createdBy
@@ -70,8 +71,22 @@ func NewVersionMetaData(version string, createdBy string, createdOn time.Time, t
 func NewVersionMetaDataWithDefaults() *VersionMetaData {
 	this := VersionMetaData{}
 
+
+
+
+
+
+
+
+
+
+
+
+
+
 	return &this
 }
+
 
 // GetVersion returns the Version field value
 func (o *VersionMetaData) GetVersion() string {
@@ -86,7 +101,7 @@ func (o *VersionMetaData) GetVersion() string {
 // GetVersionOk returns a tuple with the Version field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetVersionOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Version, true
@@ -96,6 +111,7 @@ func (o *VersionMetaData) GetVersionOk() (*string, bool) {
 func (o *VersionMetaData) SetVersion(v string) {
 	o.Version = v
 }
+
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *VersionMetaData) GetName() string {
@@ -129,6 +145,7 @@ func (o *VersionMetaData) SetName(v string) {
 	o.Name = &v
 }
 
+
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *VersionMetaData) GetDescription() string {
 	if o == nil || o.Description == nil {
@@ -161,6 +178,7 @@ func (o *VersionMetaData) SetDescription(v string) {
 	o.Description = &v
 }
 
+
 // GetCreatedBy returns the CreatedBy field value
 func (o *VersionMetaData) GetCreatedBy() string {
 	if o == nil {
@@ -174,7 +192,7 @@ func (o *VersionMetaData) GetCreatedBy() string {
 // GetCreatedByOk returns a tuple with the CreatedBy field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetCreatedByOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedBy, true
@@ -185,10 +203,11 @@ func (o *VersionMetaData) SetCreatedBy(v string) {
 	o.CreatedBy = v
 }
 
+
 // GetCreatedOn returns the CreatedOn field value
-func (o *VersionMetaData) GetCreatedOn() time.Time {
+func (o *VersionMetaData) GetCreatedOn() string {
 	if o == nil {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 
@@ -197,17 +216,18 @@ func (o *VersionMetaData) GetCreatedOn() time.Time {
 
 // GetCreatedOnOk returns a tuple with the CreatedOn field value
 // and a boolean to check if the value has been set.
-func (o *VersionMetaData) GetCreatedOnOk() (*time.Time, bool) {
-	if o == nil {
+func (o *VersionMetaData) GetCreatedOnOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.CreatedOn, true
 }
 
 // SetCreatedOn sets field value
-func (o *VersionMetaData) SetCreatedOn(v time.Time) {
+func (o *VersionMetaData) SetCreatedOn(v string) {
 	o.CreatedOn = v
 }
+
 
 // GetType returns the Type field value
 func (o *VersionMetaData) GetType() ArtifactType {
@@ -222,7 +242,7 @@ func (o *VersionMetaData) GetType() ArtifactType {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetTypeOk() (*ArtifactType, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -232,6 +252,7 @@ func (o *VersionMetaData) GetTypeOk() (*ArtifactType, bool) {
 func (o *VersionMetaData) SetType(v ArtifactType) {
 	o.Type = v
 }
+
 
 // GetGlobalId returns the GlobalId field value
 func (o *VersionMetaData) GetGlobalId() int64 {
@@ -246,7 +267,7 @@ func (o *VersionMetaData) GetGlobalId() int64 {
 // GetGlobalIdOk returns a tuple with the GlobalId field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetGlobalIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.GlobalId, true
@@ -256,6 +277,7 @@ func (o *VersionMetaData) GetGlobalIdOk() (*int64, bool) {
 func (o *VersionMetaData) SetGlobalId(v int64) {
 	o.GlobalId = v
 }
+
 
 // GetState returns the State field value if set, zero value otherwise.
 func (o *VersionMetaData) GetState() ArtifactState {
@@ -289,6 +311,7 @@ func (o *VersionMetaData) SetState(v ArtifactState) {
 	o.State = &v
 }
 
+
 // GetId returns the Id field value
 func (o *VersionMetaData) GetId() string {
 	if o == nil {
@@ -302,7 +325,7 @@ func (o *VersionMetaData) GetId() string {
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetIdOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Id, true
@@ -312,6 +335,7 @@ func (o *VersionMetaData) GetIdOk() (*string, bool) {
 func (o *VersionMetaData) SetId(v string) {
 	o.Id = v
 }
+
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
 func (o *VersionMetaData) GetLabels() []string {
@@ -345,6 +369,7 @@ func (o *VersionMetaData) SetLabels(v []string) {
 	o.Labels = &v
 }
 
+
 // GetProperties returns the Properties field value if set, zero value otherwise.
 func (o *VersionMetaData) GetProperties() map[string]string {
 	if o == nil || o.Properties == nil {
@@ -376,6 +401,7 @@ func (o *VersionMetaData) HasProperties() bool {
 func (o *VersionMetaData) SetProperties(v map[string]string) {
 	o.Properties = &v
 }
+
 
 // GetGroupId returns the GroupId field value if set, zero value otherwise.
 func (o *VersionMetaData) GetGroupId() string {
@@ -409,6 +435,7 @@ func (o *VersionMetaData) SetGroupId(v string) {
 	o.GroupId = &v
 }
 
+
 // GetContentId returns the ContentId field value
 func (o *VersionMetaData) GetContentId() int64 {
 	if o == nil {
@@ -422,7 +449,7 @@ func (o *VersionMetaData) GetContentId() int64 {
 // GetContentIdOk returns a tuple with the ContentId field value
 // and a boolean to check if the value has been set.
 func (o *VersionMetaData) GetContentIdOk() (*int64, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ContentId, true
@@ -433,61 +460,62 @@ func (o *VersionMetaData) SetContentId(v int64) {
 	o.ContentId = v
 }
 
+
 func (o VersionMetaData) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-
+	
 	if true {
 		toSerialize["version"] = o.Version
 	}
-
+    
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
+    
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
 	}
-
+    
 	if true {
 		toSerialize["createdBy"] = o.CreatedBy
 	}
-
+    
 	if true {
 		toSerialize["createdOn"] = o.CreatedOn
 	}
-
+    
 	if true {
 		toSerialize["type"] = o.Type
 	}
-
+    
 	if true {
 		toSerialize["globalId"] = o.GlobalId
 	}
-
+    
 	if o.State != nil {
 		toSerialize["state"] = o.State
 	}
-
+    
 	if true {
 		toSerialize["id"] = o.Id
 	}
-
+    
 	if o.Labels != nil {
 		toSerialize["labels"] = o.Labels
 	}
-
+    
 	if o.Properties != nil {
 		toSerialize["properties"] = o.Properties
 	}
-
+    
 	if o.GroupId != nil {
 		toSerialize["groupId"] = o.GroupId
 	}
-
+    
 	if true {
 		toSerialize["contentId"] = o.ContentId
 	}
-
+    
 	return json.Marshal(toSerialize)
 }
 
@@ -526,3 +554,4 @@ func (v *NullableVersionMetaData) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/scripts/patch_apis.sh
+++ b/scripts/patch_apis.sh
@@ -1,10 +1,14 @@
 echo "Patching service registry instances"
 
+cd .openapi
 echo "Removing codegen "
-cat ./.openapi/registry-instance.json | jq 'del(.paths."x-codegen-contextRoot")'  > ./.openapi/registry-instance-tmp.json
+cat registry-instance.json | jq 'del(.paths."x-codegen-contextRoot")'  > registry-instance-tmp.json
 echo "Ensuring only single tag is created "
-cat ./.openapi/registry-instance.json | jq 'walk( if type == "object" and has("tags") 
+cat registry-instance.json | jq 'walk( if type == "object" and has("tags") 
        then .tags |= select(.[0])
-       else . end )' > ./.openapi/registry-instance-tmp.json
+       else . end )' > registry-instance-tmp.json
 
-mv -f ./.openapi/registry-instance-tmp.json  ./.openapi/registry-instance.json
+echo "Removing invalid datetime definitions"
+sed -i '' 's/date-time/utc-date/' registry-instance-tmp.json
+
+mv -f registry-instance-tmp.json registry-instance.json


### PR DESCRIPTION
Backend cannot fix/change format so we need to get them as strings and manually parse each time on client.