### PR TITLE
chore: add a hack for multi-module repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 * **auth**: move Endpoint type to a new oauth2 package
-* 
+
 ### Bug Fixes
 
 * **deps:** update module github.com/getkin/kin-openapi to v0.74.0 ([#235](https://github.com/redhat-developer/app-services-sdk-go/issues/235))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [v0.9.6](https://github.com/redhat-developer/app-services-sdk-go/compare/v0.9.5...v0.9.6) (2021-08-17)
+
+### Features
+
+* **auth**: move Endpoint type to a new oauth2 package
+* 
+### Bug Fixes
+
+* **deps:** update module github.com/getkin/kin-openapi to v0.74.0 ([#235](https://github.com/redhat-developer/app-services-sdk-go/issues/235))
+* **deps:** update module github.com/getkin/kin-openapi to v0.73.0 ([#234](https://github.com/redhat-developer/app-services-sdk-go/issues/234))
+* **deps:** update module github.com/getkin/kin-openapi to v0.72.0 ([#233](https://github.com/redhat-developer/app-services-sdk-go/issues/233))

--- a/connectormgmt/go.mod
+++ b/connectormgmt/go.mod
@@ -2,4 +2,7 @@ module github.com/redhat-developer/app-services-sdk-go/connectormgmt
 
 go 1.13
 
-require golang.org/x/oauth2 v0.0.0-20210817223510-7df4dd6e12ab
+require (
+	github.com/redhat-developer/app-services-sdk-go v0.9.6
+	golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5
+)

--- a/connectormgmt/go_mod_tidy_hack.go
+++ b/connectormgmt/go_mod_tidy_hack.go
@@ -1,0 +1,6 @@
+// This file won't be included int the client build
+// +build modhack
+package kafkamgmt
+
+// Necessary for safely adding multi-module repo. See https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/redhat-developer/app-services-sdk-go"

--- a/go_mod_tidy_hack.go
+++ b/go_mod_tidy_hack.go
@@ -1,0 +1,4 @@
+// This file won't be included in the client build
+// +build modhack
+
+package rhoas

--- a/kafkainstance/go.mod
+++ b/kafkainstance/go.mod
@@ -2,4 +2,7 @@ module github.com/redhat-developer/app-services-sdk-go/kafkainstance
 
 go 1.13
 
-require golang.org/x/oauth2 v0.0.0-20210817223510-7df4dd6e12ab
+require (
+	github.com/redhat-developer/app-services-sdk-go v0.9.6
+	golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5
+)

--- a/kafkainstance/go_mod_tidy_hack.go
+++ b/kafkainstance/go_mod_tidy_hack.go
@@ -1,0 +1,7 @@
+// This file won't be included int the client build
+// +build modhack
+
+package kafkamgmt
+
+// Necessary for safely adding multi-module repo. See https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/redhat-developer/app-services-sdk-go"

--- a/kafkamgmt/go.mod
+++ b/kafkamgmt/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-developer/app-services-sdk-go/kafkamgmt
 go 1.13
 
 require (
+	github.com/redhat-developer/app-services-sdk-go v0.9.6
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	golang.org/x/oauth2 v0.0.0-20210817223510-7df4dd6e12ab
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/kafkamgmt/go_mod_tidy_hack.go
+++ b/kafkamgmt/go_mod_tidy_hack.go
@@ -1,0 +1,7 @@
+// This file won't be included in the client build
+// +build modhack
+
+package kafkamgmt
+
+// Necessary for safely adding multi-module repo. See https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/redhat-developer/app-services-sdk-go"

--- a/registryinstance/go.mod
+++ b/registryinstance/go.mod
@@ -2,4 +2,7 @@ module github.com/redhat-developer/app-services-sdk-go/registryinstance
 
 go 1.13
 
-require golang.org/x/oauth2 v0.0.0-20210817223510-7df4dd6e12ab
+require (
+	github.com/redhat-developer/app-services-sdk-go v0.9.6
+	golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5
+)

--- a/registryinstance/go_mod_tidy_hack.go
+++ b/registryinstance/go_mod_tidy_hack.go
@@ -1,0 +1,7 @@
+// This file won't be included int the client build
+// +build modhack
+
+package kafkamgmt
+
+// Necessary for safely adding multi-module repo. See https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/redhat-developer/app-services-sdk-go"

--- a/registrymgmt/go.mod
+++ b/registrymgmt/go.mod
@@ -2,4 +2,7 @@ module github.com/redhat-developer/app-services-sdk-go/registrymgmt
 
 go 1.13
 
-require golang.org/x/oauth2 v0.0.0-20210817223510-7df4dd6e12ab
+require (
+	github.com/redhat-developer/app-services-sdk-go v0.9.6
+	golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5
+)

--- a/registrymgmt/go_mod_tidy_hack.go
+++ b/registrymgmt/go_mod_tidy_hack.go
@@ -1,0 +1,7 @@
+// This file won't be included int the client build
+// +build modhack
+
+package kafkamgmt
+
+// Necessary for safely adding multi-module repo. See https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/redhat-developer/app-services-sdk-go"


### PR DESCRIPTION
See [Is it possible to add a module to a multi-module repository?](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository)

TL;DR - we are converting former packages (which already exist in source control and pkg.go.dev) to submodules. This requires this temporary "hack" to prevent "ambiguous imports" from occurring at compile time.

This hack makes the newly-added module depend on the module it was "carved out" from, at a version after which it was carved out.

## Verification Steps

1. `cd kafkamgmt`
3. `git commit -m "temp"`
2. `git tag v0.9.6 && git tag kafkamgmt/v0.3.0`
3. `go mod edit -replace github.com/redhat-developer/app-services-sdk-go@v0.9.6=../`
4. `go test ./...`:

You should see an output similar to this:

```shell
?       github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1 [no test files]
?       github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client  [no test files]
```

5. `go mod tidy` - if successful there will be no output.
6. `go mod edit -dropreplace github.com/redhat-developer/app-services-sdk-go@v0.9.6`
7. Once all previous steps have been completed you may delete thew tags: `git tag -d v0.9.6 && git tag -d kafkamgmt/v0.3.0`