### PR TITLE
fix: add missing sdk error helper methods

### DIFF
--- a/connectormgmt/README.md
+++ b/connectormgmt/README.md
@@ -69,6 +69,23 @@ client := connectormgmt.NewAPIClient(&connectormgmt.Config{
 connectors, _, err := client.DefaultApi.GetConnectors(ctx).Execute()
 ```
 
+## Error handling
+
+Checking specific error codes
+
+```go
+if connectormgmt.IsAPIError(err, connectormgmt.ERROR_4){
+ // Do something
+}
+```
+
+Obtaining API error 
+
+```go
+apiError := connectormgmt.GetAPIError(err)
+fmt.Println(apiError.Code)
+```
+
 ## Endpoints
 
 For a full list of the available endpoints, see [Documentation for API Endpoints](./client/README.md#documentation-for-api-endpoints).

--- a/connectormgmt/apiv1/error_sdk.go
+++ b/connectormgmt/apiv1/error_sdk.go
@@ -1,0 +1,37 @@
+package connectormgmt
+
+import (
+	"errors"
+
+	connectormgmtclient "github.com/redhat-developer/app-services-sdk-go/connectormgmt/apiv1/client"
+)
+
+// Code supplied by the API
+type ServiceErrorCode string
+
+// GetAPIError gets a strongly typed error from an error
+func GetAPIError(err error) *connectormgmtclient.Error {
+	var openapiError connectormgmtclient.GenericOpenAPIError
+
+	if ok := errors.As(err, &openapiError); ok {
+		errModel := openapiError.Model()
+
+		transformedError, ok := errModel.(connectormgmtclient.Error)
+		if !ok {
+			return nil
+		}
+		return &transformedError
+	}
+
+	return nil
+}
+
+// IsAPIError returns true if the error contains the errCode
+func IsAPIError(err error, code ServiceErrorCode) bool {
+	mappedErr := GetAPIError(err)
+	if mappedErr == nil {
+		return false
+	}
+
+	return mappedErr.GetCode() == string(code)
+}

--- a/registrymgmt/README.md
+++ b/registrymgmt/README.md
@@ -69,6 +69,23 @@ client := registrymgmt.NewAPIClient(&registrymgmt.Config{
 registries, _, err := client.RegistriesApi.GetRegistries(ctx).Execute()
 ```
 
+## Error handling
+
+Checking specific error codes
+
+```go
+if registrymgmt.IsAPIError(err, registrymgmt.ERROR_4){
+ // Do something
+}
+```
+
+Obtaining API error 
+
+```go
+apiError := registrymgmt.GetAPIError(err)
+fmt.Println(apiError.Code)
+```
+
 ## Endpoints
 
 For a full list of the available endpoints, see [Documentation for API Endpoints](./client/README.md#documentation-for-api-endpoints).

--- a/registrymgmt/apiv1/error_sdk.go
+++ b/registrymgmt/apiv1/error_sdk.go
@@ -1,0 +1,37 @@
+package registrymgmt
+
+import (
+	"errors"
+
+	registrymgmtclient "github.com/redhat-developer/app-services-sdk-go/connectormgmt/apiv1/client"
+)
+
+// Code supplied by the API
+type ServiceErrorCode string
+
+// GetAPIError gets a strongly typed error from an error
+func GetAPIError(err error) *registrymgmtclient.Error {
+	var openapiError registrymgmtclient.GenericOpenAPIError
+
+	if ok := errors.As(err, &openapiError); ok {
+		errModel := openapiError.Model()
+
+		transformedError, ok := errModel.(registrymgmtclient.Error)
+		if !ok {
+			return nil
+		}
+		return &transformedError
+	}
+
+	return nil
+}
+
+// IsAPIError returns true if the error contains the errCode
+func IsAPIError(err error, code ServiceErrorCode) bool {
+	mappedErr := GetAPIError(err)
+	if mappedErr == nil {
+		return false
+	}
+
+	return mappedErr.GetCode() == string(code)
+}


### PR DESCRIPTION
Verified that with CLI and I think we need all sdks having the same helpers provided.