### PR TITLE
fix: move to use strings to avoid casting

### DIFF
--- a/connectormgmt/apiv1/error/errors.go
+++ b/connectormgmt/apiv1/error/errors.go
@@ -2,128 +2,127 @@
 package error
 
 // connectormgmt error codes 
-type ErrorCode string
   
 const (
 
   // Forbidden to perform this action
-  ERROR_4 ErrorCode = "CONNECTOR-MGMT-4"
+  ERROR_4 string = "CONNECTOR-MGMT-4"
 
   // Forbidden to create more instances than the maximum allowed
-  ERROR_5 ErrorCode = "CONNECTOR-MGMT-5"
+  ERROR_5 string = "CONNECTOR-MGMT-5"
 
   // An entity with the specified unique values already exists
-  ERROR_6 ErrorCode = "CONNECTOR-MGMT-6"
+  ERROR_6 string = "CONNECTOR-MGMT-6"
 
   // Resource not found
-  ERROR_7 ErrorCode = "CONNECTOR-MGMT-7"
+  ERROR_7 string = "CONNECTOR-MGMT-7"
 
   // General validation failure
-  ERROR_8 ErrorCode = "CONNECTOR-MGMT-8"
+  ERROR_8 string = "CONNECTOR-MGMT-8"
 
   // Unspecified error
-  ERROR_9 ErrorCode = "CONNECTOR-MGMT-9"
+  ERROR_9 string = "CONNECTOR-MGMT-9"
 
   // HTTP Method not implemented for this endpoint
-  ERROR_10 ErrorCode = "CONNECTOR-MGMT-10"
+  ERROR_10 string = "CONNECTOR-MGMT-10"
 
   // Account is unauthorized to perform this action
-  ERROR_11 ErrorCode = "CONNECTOR-MGMT-11"
+  ERROR_11 string = "CONNECTOR-MGMT-11"
 
   // Required terms have not been accepted
-  ERROR_12 ErrorCode = "CONNECTOR-MGMT-12"
+  ERROR_12 string = "CONNECTOR-MGMT-12"
 
   // Account authentication could not be verified
-  ERROR_15 ErrorCode = "CONNECTOR-MGMT-15"
+  ERROR_15 string = "CONNECTOR-MGMT-15"
 
   // Unable to read request body
-  ERROR_17 ErrorCode = "CONNECTOR-MGMT-17"
+  ERROR_17 string = "CONNECTOR-MGMT-17"
 
   // Bad request
-  ERROR_21 ErrorCode = "CONNECTOR-MGMT-21"
+  ERROR_21 string = "CONNECTOR-MGMT-21"
 
   // Failed to parse search query
-  ERROR_23 ErrorCode = "CONNECTOR-MGMT-23"
+  ERROR_23 string = "CONNECTOR-MGMT-23"
 
   // The maximum number of allowed kafka instances has been reached
-  ERROR_24 ErrorCode = "CONNECTOR-MGMT-24"
+  ERROR_24 string = "CONNECTOR-MGMT-24"
 
   // Resource gone
-  ERROR_25 ErrorCode = "CONNECTOR-MGMT-25"
+  ERROR_25 string = "CONNECTOR-MGMT-25"
 
   // Provider not supported
-  ERROR_30 ErrorCode = "CONNECTOR-MGMT-30"
+  ERROR_30 string = "CONNECTOR-MGMT-30"
 
   // Region not supported
-  ERROR_31 ErrorCode = "CONNECTOR-MGMT-31"
+  ERROR_31 string = "CONNECTOR-MGMT-31"
 
   // Kafka cluster name is invalid
-  ERROR_32 ErrorCode = "CONNECTOR-MGMT-32"
+  ERROR_32 string = "CONNECTOR-MGMT-32"
 
   // Minimum field length not reached
-  ERROR_33 ErrorCode = "CONNECTOR-MGMT-33"
+  ERROR_33 string = "CONNECTOR-MGMT-33"
 
   // Maximum field length has been depassed
-  ERROR_34 ErrorCode = "CONNECTOR-MGMT-34"
+  ERROR_34 string = "CONNECTOR-MGMT-34"
 
   // Only multiAZ Kafkas are supported, use multi_az=true
-  ERROR_35 ErrorCode = "CONNECTOR-MGMT-35"
+  ERROR_35 string = "CONNECTOR-MGMT-35"
 
   // Kafka cluster name is already used
-  ERROR_36 ErrorCode = "CONNECTOR-MGMT-36"
+  ERROR_36 string = "CONNECTOR-MGMT-36"
 
   // Field validation failed
-  ERROR_37 ErrorCode = "CONNECTOR-MGMT-37"
+  ERROR_37 string = "CONNECTOR-MGMT-37"
 
   // Service account name is invalid
-  ERROR_38 ErrorCode = "CONNECTOR-MGMT-38"
+  ERROR_38 string = "CONNECTOR-MGMT-38"
 
   // Service account desc is invalid
-  ERROR_39 ErrorCode = "CONNECTOR-MGMT-39"
+  ERROR_39 string = "CONNECTOR-MGMT-39"
 
   // Service account id is invalid
-  ERROR_40 ErrorCode = "CONNECTOR-MGMT-40"
+  ERROR_40 string = "CONNECTOR-MGMT-40"
 
   // Instance Type not supported
-  ERROR_41 ErrorCode = "CONNECTOR-MGMT-41"
+  ERROR_41 string = "CONNECTOR-MGMT-41"
 
   // Synchronous action is not supported, use async=true parameter
-  ERROR_103 ErrorCode = "CONNECTOR-MGMT-103"
+  ERROR_103 string = "CONNECTOR-MGMT-103"
 
   // Failed to create kafka client in the mas sso
-  ERROR_106 ErrorCode = "CONNECTOR-MGMT-106"
+  ERROR_106 string = "CONNECTOR-MGMT-106"
 
   // Failed to get kafka client secret from the mas sso
-  ERROR_107 ErrorCode = "CONNECTOR-MGMT-107"
+  ERROR_107 string = "CONNECTOR-MGMT-107"
 
   // Failed to get kafka client from the mas sso
-  ERROR_108 ErrorCode = "CONNECTOR-MGMT-108"
+  ERROR_108 string = "CONNECTOR-MGMT-108"
 
   // Failed to delete kafka client from the mas sso
-  ERROR_109 ErrorCode = "CONNECTOR-MGMT-109"
+  ERROR_109 string = "CONNECTOR-MGMT-109"
 
   // Failed to create service account
-  ERROR_110 ErrorCode = "CONNECTOR-MGMT-110"
+  ERROR_110 string = "CONNECTOR-MGMT-110"
 
   // Failed to get service account
-  ERROR_111 ErrorCode = "CONNECTOR-MGMT-111"
+  ERROR_111 string = "CONNECTOR-MGMT-111"
 
   // Failed to delete service account
-  ERROR_112 ErrorCode = "CONNECTOR-MGMT-112"
+  ERROR_112 string = "CONNECTOR-MGMT-112"
 
   // Failed to find service account
-  ERROR_113 ErrorCode = "CONNECTOR-MGMT-113"
+  ERROR_113 string = "CONNECTOR-MGMT-113"
 
   // Insufficient quota
-  ERROR_120 ErrorCode = "CONNECTOR-MGMT-120"
+  ERROR_120 string = "CONNECTOR-MGMT-120"
 
   // Failed to check quota
-  ERROR_121 ErrorCode = "CONNECTOR-MGMT-121"
+  ERROR_121 string = "CONNECTOR-MGMT-121"
 
   // Too Many requests
-  ERROR_429 ErrorCode = "CONNECTOR-MGMT-429"
+  ERROR_429 string = "CONNECTOR-MGMT-429"
 
   // An unexpected error happened, please check the log of the service for details
-  ERROR_1000 ErrorCode = "CONNECTOR-MGMT-1000"
+  ERROR_1000 string = "CONNECTOR-MGMT-1000"
 
 )

--- a/kafkamgmt/apiv1/error/errors.go
+++ b/kafkamgmt/apiv1/error/errors.go
@@ -2,128 +2,127 @@
 package error
 
 // kafkamgmt error codes 
-type ErrorCode string
   
 const (
 
   // Forbidden to perform this action
-  ERROR_4 ErrorCode = "KAFKAS-MGMT-4"
+  ERROR_4 string = "KAFKAS-MGMT-4"
 
   // Forbidden to create more instances than the maximum allowed
-  ERROR_5 ErrorCode = "KAFKAS-MGMT-5"
+  ERROR_5 string = "KAFKAS-MGMT-5"
 
   // An entity with the specified unique values already exists
-  ERROR_6 ErrorCode = "KAFKAS-MGMT-6"
+  ERROR_6 string = "KAFKAS-MGMT-6"
 
   // Resource not found
-  ERROR_7 ErrorCode = "KAFKAS-MGMT-7"
+  ERROR_7 string = "KAFKAS-MGMT-7"
 
   // General validation failure
-  ERROR_8 ErrorCode = "KAFKAS-MGMT-8"
+  ERROR_8 string = "KAFKAS-MGMT-8"
 
   // Unspecified error
-  ERROR_9 ErrorCode = "KAFKAS-MGMT-9"
+  ERROR_9 string = "KAFKAS-MGMT-9"
 
   // HTTP Method not implemented for this endpoint
-  ERROR_10 ErrorCode = "KAFKAS-MGMT-10"
+  ERROR_10 string = "KAFKAS-MGMT-10"
 
   // Account is unauthorized to perform this action
-  ERROR_11 ErrorCode = "KAFKAS-MGMT-11"
+  ERROR_11 string = "KAFKAS-MGMT-11"
 
   // Required terms have not been accepted
-  ERROR_12 ErrorCode = "KAFKAS-MGMT-12"
+  ERROR_12 string = "KAFKAS-MGMT-12"
 
   // Account authentication could not be verified
-  ERROR_15 ErrorCode = "KAFKAS-MGMT-15"
+  ERROR_15 string = "KAFKAS-MGMT-15"
 
   // Unable to read request body
-  ERROR_17 ErrorCode = "KAFKAS-MGMT-17"
+  ERROR_17 string = "KAFKAS-MGMT-17"
 
   // Bad request
-  ERROR_21 ErrorCode = "KAFKAS-MGMT-21"
+  ERROR_21 string = "KAFKAS-MGMT-21"
 
   // Failed to parse search query
-  ERROR_23 ErrorCode = "KAFKAS-MGMT-23"
+  ERROR_23 string = "KAFKAS-MGMT-23"
 
   // The maximum number of allowed kafka instances has been reached
-  ERROR_24 ErrorCode = "KAFKAS-MGMT-24"
+  ERROR_24 string = "KAFKAS-MGMT-24"
 
   // Resource gone
-  ERROR_25 ErrorCode = "KAFKAS-MGMT-25"
+  ERROR_25 string = "KAFKAS-MGMT-25"
 
   // Provider not supported
-  ERROR_30 ErrorCode = "KAFKAS-MGMT-30"
+  ERROR_30 string = "KAFKAS-MGMT-30"
 
   // Region not supported
-  ERROR_31 ErrorCode = "KAFKAS-MGMT-31"
+  ERROR_31 string = "KAFKAS-MGMT-31"
 
   // Kafka cluster name is invalid
-  ERROR_32 ErrorCode = "KAFKAS-MGMT-32"
+  ERROR_32 string = "KAFKAS-MGMT-32"
 
   // Minimum field length not reached
-  ERROR_33 ErrorCode = "KAFKAS-MGMT-33"
+  ERROR_33 string = "KAFKAS-MGMT-33"
 
   // Maximum field length has been depassed
-  ERROR_34 ErrorCode = "KAFKAS-MGMT-34"
+  ERROR_34 string = "KAFKAS-MGMT-34"
 
   // Only multiAZ Kafkas are supported, use multi_az=true
-  ERROR_35 ErrorCode = "KAFKAS-MGMT-35"
+  ERROR_35 string = "KAFKAS-MGMT-35"
 
   // Kafka cluster name is already used
-  ERROR_36 ErrorCode = "KAFKAS-MGMT-36"
+  ERROR_36 string = "KAFKAS-MGMT-36"
 
   // Field validation failed
-  ERROR_37 ErrorCode = "KAFKAS-MGMT-37"
+  ERROR_37 string = "KAFKAS-MGMT-37"
 
   // Service account name is invalid
-  ERROR_38 ErrorCode = "KAFKAS-MGMT-38"
+  ERROR_38 string = "KAFKAS-MGMT-38"
 
   // Service account desc is invalid
-  ERROR_39 ErrorCode = "KAFKAS-MGMT-39"
+  ERROR_39 string = "KAFKAS-MGMT-39"
 
   // Service account id is invalid
-  ERROR_40 ErrorCode = "KAFKAS-MGMT-40"
+  ERROR_40 string = "KAFKAS-MGMT-40"
 
   // Instance Type not supported
-  ERROR_41 ErrorCode = "KAFKAS-MGMT-41"
+  ERROR_41 string = "KAFKAS-MGMT-41"
 
   // Synchronous action is not supported, use async=true parameter
-  ERROR_103 ErrorCode = "KAFKAS-MGMT-103"
+  ERROR_103 string = "KAFKAS-MGMT-103"
 
   // Failed to create kafka client in the mas sso
-  ERROR_106 ErrorCode = "KAFKAS-MGMT-106"
+  ERROR_106 string = "KAFKAS-MGMT-106"
 
   // Failed to get kafka client secret from the mas sso
-  ERROR_107 ErrorCode = "KAFKAS-MGMT-107"
+  ERROR_107 string = "KAFKAS-MGMT-107"
 
   // Failed to get kafka client from the mas sso
-  ERROR_108 ErrorCode = "KAFKAS-MGMT-108"
+  ERROR_108 string = "KAFKAS-MGMT-108"
 
   // Failed to delete kafka client from the mas sso
-  ERROR_109 ErrorCode = "KAFKAS-MGMT-109"
+  ERROR_109 string = "KAFKAS-MGMT-109"
 
   // Failed to create service account
-  ERROR_110 ErrorCode = "KAFKAS-MGMT-110"
+  ERROR_110 string = "KAFKAS-MGMT-110"
 
   // Failed to get service account
-  ERROR_111 ErrorCode = "KAFKAS-MGMT-111"
+  ERROR_111 string = "KAFKAS-MGMT-111"
 
   // Failed to delete service account
-  ERROR_112 ErrorCode = "KAFKAS-MGMT-112"
+  ERROR_112 string = "KAFKAS-MGMT-112"
 
   // Failed to find service account
-  ERROR_113 ErrorCode = "KAFKAS-MGMT-113"
+  ERROR_113 string = "KAFKAS-MGMT-113"
 
   // Insufficient quota
-  ERROR_120 ErrorCode = "KAFKAS-MGMT-120"
+  ERROR_120 string = "KAFKAS-MGMT-120"
 
   // Failed to check quota
-  ERROR_121 ErrorCode = "KAFKAS-MGMT-121"
+  ERROR_121 string = "KAFKAS-MGMT-121"
 
   // Too Many requests
-  ERROR_429 ErrorCode = "KAFKAS-MGMT-429"
+  ERROR_429 string = "KAFKAS-MGMT-429"
 
   // An unexpected error happened, please check the log of the service for details
-  ERROR_1000 ErrorCode = "KAFKAS-MGMT-1000"
+  ERROR_1000 string = "KAFKAS-MGMT-1000"
 
 )

--- a/registrymgmt/apiv1/error/errors.go
+++ b/registrymgmt/apiv1/error/errors.go
@@ -2,38 +2,37 @@
 package error
 
 // registrymgmt error codes 
-type ErrorCode string
   
 const (
 
   // Unspecified error
-  ERROR_1 ErrorCode = "SRS-MGMT-1"
+  ERROR_1 string = "SRS-MGMT-1"
 
   // Registry with id='?' not found
-  ERROR_2 ErrorCode = "SRS-MGMT-2"
+  ERROR_2 string = "SRS-MGMT-2"
 
   // Bad date or time format
-  ERROR_3 ErrorCode = "SRS-MGMT-3"
+  ERROR_3 string = "SRS-MGMT-3"
 
   // Invalid request content. Make sure the request conforms to the given JSON schema
-  ERROR_4 ErrorCode = "SRS-MGMT-4"
+  ERROR_4 string = "SRS-MGMT-4"
 
   // Bad request format - invalid JSON
-  ERROR_5 ErrorCode = "SRS-MGMT-5"
+  ERROR_5 string = "SRS-MGMT-5"
 
   // Required terms have not been accepted for account id='?'
-  ERROR_6 ErrorCode = "SRS-MGMT-6"
+  ERROR_6 string = "SRS-MGMT-6"
 
   // The maximum number of allowed Registry instances has been reached
-  ERROR_7 ErrorCode = "SRS-MGMT-7"
+  ERROR_7 string = "SRS-MGMT-7"
 
   // Error type with id='?' not found
-  ERROR_8 ErrorCode = "SRS-MGMT-8"
+  ERROR_8 string = "SRS-MGMT-8"
 
   // Data conflict. Make sure a Registry with the given name does not already exist
-  ERROR_9 ErrorCode = "SRS-MGMT-9"
+  ERROR_9 string = "SRS-MGMT-9"
 
   // Bad request format - unsupported media type
-  ERROR_10 ErrorCode = "SRS-MGMT-10"
+  ERROR_10 string = "SRS-MGMT-10"
 
 )

--- a/scripts/errors/generate-errors.js
+++ b/scripts/errors/generate-errors.js
@@ -18,7 +18,6 @@ for (api in apis) {
 package error
 
 // ${api} error codes 
-type ErrorCode string
   
 const (
 
@@ -26,7 +25,7 @@ const (
   
   apiJson.items.forEach(function(errorType) {
     stringBuffer += `  // ${errorType.reason}\n`
-    stringBuffer += `  ERROR_${errorType.id} ErrorCode = "${errorType.code}"`
+    stringBuffer += `  ERROR_${errorType.id} string = "${errorType.code}"`
     stringBuffer += `\n\n`
   })
   


### PR DESCRIPTION
Another problem is that when using string we need to cast error codes defined with other type as string which is not how we documented that. I would change every instance to be string to avoid problems