### PR TITLE
chore: replace hard-code reviewers with dynamic team

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -33,7 +33,7 @@ jobs:
           author: "app-services-ci <app-services-ci@users.noreply.github.com>"
           branch: chore/generate-api-clients
           branch-suffix: timestamp
-          reviewers: craicoverflow, wtrocki
+          reviewers: '@redhat-developer/app-services-sdk-maintainers'
           delete-branch: true
           body: |
             _This pull request was auto-generated_

--- a/.github/workflows/generate_errors.yaml
+++ b/.github/workflows/generate_errors.yaml
@@ -31,7 +31,7 @@ jobs:
           author: "app-services-ci <app-services-ci@users.noreply.github.com>"
           branch: chore/generate-sdks-errors
           branch-suffix: timestamp
-          reviewers: craicoverflow, wtrocki
+          reviewers: '@redhat-developer/app-services-sdk-maintainers'
           delete-branch: true
           body: |
             _This pull request was auto-generated_

--- a/.github/workflows/update_openapi.yaml
+++ b/.github/workflows/update_openapi.yaml
@@ -67,7 +67,7 @@ jobs:
           author: "app-services-ci <app-services-ci@users.noreply.github.com>"
           branch: chore/add-${{ env.CLIENT_ID }}-openapi
           branch-suffix: timestamp
-          reviewers: craicoverflow, wtrocki
+          reviewers: '@redhat-developer/app-services-sdk-maintainers'
           delete-branch: true
           body: >
             _This pull request was auto-generated_


### PR DESCRIPTION
I think it will be better to replace hard-coded reviewers with a new team (@redhat-developer/app-services-sdk-maintainers) in GitHub. This will make the process of adding or removing reviewers much simpler in the future and it can be applied across all SDKs.