### PR TITLE
Updating the service accounts api openapi specification

### DIFF
--- a/.openapi/service-accounts.yaml
+++ b/.openapi/service-accounts.yaml
@@ -15,6 +15,7 @@ servers:
 security:
 - authFlow: []
 - serviceAccounts: []
+- bearerAuth: []
 paths:
   /apis/service_accounts/v1:
     get:
@@ -408,6 +409,10 @@ components:
         error: service_account_limit_exceeded
         error_description: Cannot create more than 50 service accounts per account.
   securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     authFlow:
       type: oauth2
       flows:

--- a/.openapi/service-accounts.yaml
+++ b/.openapi/service-accounts.yaml
@@ -6,45 +6,50 @@ info:
     email: it-user-team-list@redhat.com
   version: 5.0.19
 servers:
-  - url: https://sso.redhat.com/auth/realms/redhat-external
-    description: Production server
+- url: https://sso.redhat.com/auth/realms/redhat-external
+  description: Production server
+- url: https://sso.stage.redhat.com/auth/realms/redhat-external
+  description: Stage server
+- url: http://localhost:8081/auth/realms/redhat-external
+  description: Local development
 security:
-  - bearerAuth: []
+- authFlow: []
+- serviceAccounts: []
 paths:
   /apis/service_accounts/v1:
     get:
       tags:
-        - service_accounts
+      - service_accounts
       summary: List all service accounts
       description: Returns a list of service accounts created by a user. User information
         is obtained from the bearer token. The list is paginated with starting index
         as 'first' and page size as 'max'.
       operationId: getServiceAccounts
       parameters:
-        - name: first
-          in: query
-          schema:
-            minimum: 0
-            type: integer
-            format: int32
-            default: 0
-        - name: max
-          in: query
-          schema:
-            maximum: 100
-            minimum: 1
-            type: integer
-            format: int32
-            default: 20
-        - name: clientId
-          in: query
-          schema:
-            maxItems: 10
-            minItems: 0
-            uniqueItems: true
-            type: array
-            items:
-              type: string
+      - name: first
+        in: query
+        schema:
+          minimum: 0
+          type: integer
+          format: int32
+          default: 0
+      - name: max
+        in: query
+        schema:
+          maximum: 100
+          minimum: 1
+          type: integer
+          format: int32
+          default: 20
+      - name: clientId
+        in: query
+        schema:
+          maxItems: 10
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            type: string
       responses:
         "200":
           description: OK
@@ -59,12 +64,25 @@ paths:
               operationId: getServiceAccounts
               description: link to the next page of service accounts
         "400":
-          $ref: '#/components/responses/400'
+          description: Bad Request if page filters are invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationExceptionData'
+              examples:
+                Bad Request Example:
+                  description: Bad Request Example
+                  $ref: '#/components/examples/400FieldValidationError'
         "401":
           $ref: '#/components/responses/401'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
     post:
       tags:
-        - service_accounts
+      - service_accounts
       summary: Create service account
       description: Create a service account. Created service account is associated
         with the user defined in the bearer token.
@@ -84,24 +102,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceAccountData'
         "400":
-          $ref: '#/components/responses/400'
+          description: All fields did not pass validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationExceptionData'
+              examples:
+                Bad Request Example:
+                  description: Bad Request Example
+                  $ref: '#/components/examples/400FieldValidationError'
         "401":
           $ref: '#/components/responses/401'
+        "403":
+          description: Exceeded account level threshold limits for creating service
+            accounts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedHatErrorRepresentation'
+              examples:
+                service account threshold exceeded:
+                  description: service account threshold exceeded
+                  $ref: '#/components/examples/403ServiceAccountThresholdExceeded'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
   /apis/service_accounts/v1/{id}:
     get:
       tags:
-        - service_accounts
+      - service_accounts
       summary: Get service account by id
       description: Returns service account by id. Throws not found exception if the
         service account is not found or the user does not have access to this service
         account
       operationId: getServiceAccount
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
@@ -109,45 +151,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceAccountData'
-        "404":
-          $ref: '#/components/responses/404'
         "401":
           $ref: '#/components/responses/401'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedHatErrorRepresentation'
+              examples:
+                service account not found:
+                  description: service account not found
+                  $ref: '#/components/examples/404ServiceAccountNotFound'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
     delete:
       tags:
-        - service_accounts
+      - service_accounts
       summary: Delete service account by id
       description: Delete service account by id. Throws not found exception if the
         service account is not found or the user does not have access to this service
         account
       operationId: deleteServiceAccount
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
           content:
             application/json: {}
-        "404":
-          $ref: '#/components/responses/404'
         "401":
           $ref: '#/components/responses/401'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedHatErrorRepresentation'
+              examples:
+                service account not found:
+                  description: service account not found
+                  $ref: '#/components/examples/404ServiceAccountNotFound'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
     patch:
       tags:
-        - service_accounts
+      - service_accounts
       summary: Update service account
       description: Update a service account by id.
       operationId: updateServiceAccount
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       requestBody:
         description: '''name'' and ''description'' of the service account'
         content:
@@ -163,26 +231,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceAccountData'
         "400":
-          $ref: '#/components/responses/400'
-        "404":
-          $ref: '#/components/responses/404'
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationExceptionData'
+              examples:
+                Bad Request Example:
+                  description: Bad Request Example
+                  $ref: '#/components/examples/400FieldValidationError'
         "401":
           $ref: '#/components/responses/401'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedHatErrorRepresentation'
+              examples:
+                service account not found:
+                  description: service account not found
+                  $ref: '#/components/examples/404ServiceAccountNotFound'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
   /apis/service_accounts/v1/{id}/resetSecret:
     post:
       tags:
-        - service_accounts
+      - service_accounts
       summary: Reset service account secret by id
       description: Reset service account secret by id . Throws not found exception
         if the service account is not found or the user does not have access to this
         service account
       operationId: resetServiceAccountSecret
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
@@ -190,15 +279,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceAccountData'
-        "404":
-          $ref: '#/components/responses/404'
         "401":
           $ref: '#/components/responses/401'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedHatErrorRepresentation'
+              examples:
+                service account not found:
+                  description: service account not found
+                  $ref: '#/components/examples/404ServiceAccountNotFound'
+      security:
+      - authFlow:
+        - api.iam.service_accounts
+      - serviceAccounts:
+        - api.iam.service_accounts
 components:
   schemas:
     Error:
       required:
-        - error
+      - error
       type: object
       properties:
         error:
@@ -223,30 +325,55 @@ components:
         createdAt:
           type: integer
           format: int64
+    ValidationExceptionData:
+      type: object
+      properties:
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+        error:
+          type: string
+          example: invalid_field
+        error_description:
+          type: string
+    RedHatErrorRepresentation:
+      type: object
+      properties:
+        error:
+          type: string
+          enum:
+          - service_account_limit_exceeded
+          - service_account_not_found
+          - service_account_user_not_found
+          - service_account_access_invalid
+        error_description:
+          type: string
     ServiceAccountCreateRequestData:
       required:
-        - description
-        - name
+      - name
       type: object
       properties:
         name:
+          maxLength: 50
+          minLength: 1
           type: string
         description:
+          maxLength: 255
+          minLength: 0
           type: string
     ServiceAccountRequestData:
       type: object
       properties:
         name:
+          maxLength: 50
+          minLength: 1
           type: string
         description:
+          maxLength: 255
+          minLength: 0
           type: string
   responses:
-    "400":
-      description: Bad Request
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
     "401":
       description: Unauthorized
       content:
@@ -259,21 +386,42 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    "404":
-      description: Not Found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
     "500":
       description: Internal Server Error
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+  examples:
+    "400FieldValidationError":
+      value:
+        error: invalid_field
+        error_description: Request failed field validation
+        fields:
+          name: description of constraint which failed
+    "404ServiceAccountNotFound":
+      value:
+        error: service_account_not_found
+        error_description: Service account 1234 not found.
+    "403ServiceAccountThresholdExceeded":
+      value:
+        error: service_account_limit_exceeded
+        error_description: Cannot create more than 50 service accounts per account.
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      
+    authFlow:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /auth/realms/redhat-external/protocol/openid-connect/auth
+          tokenUrl: /auth/realms/redhat-external/protocol/openid-connect/token
+          scopes:
+            openid: Treat as an OIDC request
+            api.iam.service_accounts: Grants access to the service accounts api
+    serviceAccounts:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: /auth/realms/redhat-external/protocol/openid-connect/token
+          scopes:
+            openid: Treat as an OIDC request
+            api.iam.service_accounts: Grants access to the service accounts api


### PR DESCRIPTION
@eatikrh, @wtrocki 

@eatikrh and I made some changes to the spec. Let us know if the changes to the auth have some negative effect on the clients using the generated libraries.

Change list:

Relaxing constraint on description. It is no longer required.
Setting max char length of name to 50. description is 255.

Adding examples for 400 status code responses.

Changing security methods to more accurately describe how to authenticate
using authorization flow (normal user) or client credentials flow
(service account).
Adding scopes and descriptions of use.