### PR TITLE
chore: update module name

### DIFF
--- a/serviceaccountmgmt/go.mod
+++ b/serviceaccountmgmt/go.mod
@@ -1,4 +1,4 @@
-module github.com/redhat-developer/app-services-sdk-go/serviceaccounts
+module github.com/redhat-developer/app-services-sdk-go/serviceaccountmgmt
 
 go 1.15
 


### PR DESCRIPTION
Raised a PR to fix the following issue while importing service account sdk to the CLI.

```
go: github.com/redhat-developer/app-services-sdk-go/serviceaccountmgmt@v0.0.0-20220808155507-43ad752beb3c: parsing go.mod:
        module declares its path as: github.com/redhat-developer/app-services-sdk-go/serviceaccounts
                but was required as: github.com/redhat-developer/app-services-sdk-go/serviceaccountmgmt
```