### PR TITLE
fix(registry-instance): add accept param for export

### DIFF
--- a/.openapi/registry-instance.json
+++ b/.openapi/registry-instance.json
@@ -680,6 +680,13 @@
         ],
         "parameters": [
           {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "forBrowser",
             "description": "Indicates if the operation is done for a browser.  If true, the response will be a JSON payload with a property called `href`.  This `href` will be a single-use, naked download link suitable for use by a web browser to download the content.",
             "schema": {

--- a/registryinstance/apiv1internal/client/api/openapi.yaml
+++ b/registryinstance/apiv1internal/client/api/openapi.yaml
@@ -968,6 +968,13 @@ paths:
       description: Exports registry data as a ZIP archive.
       operationId: exportData
       parameters:
+      - explode: false
+        in: header
+        name: Accept
+        required: false
+        schema:
+          type: string
+        style: simple
       - description: Indicates if the operation is done for a browser.  If true, the
           response will be a JSON payload with a property called `href`.  This `href`
           will be a single-use, naked download link suitable for use by a web browser

--- a/registryinstance/apiv1internal/client/api_admin.go
+++ b/registryinstance/apiv1internal/client/api_admin.go
@@ -539,9 +539,14 @@ func (a *AdminApiService) DeleteRoleMappingExecute(r ApiDeleteRoleMappingRequest
 type ApiExportDataRequest struct {
 	ctx _context.Context
 	ApiService AdminApi
+	accept *string
 	forBrowser *bool
 }
 
+func (r ApiExportDataRequest) Accept(accept string) ApiExportDataRequest {
+	r.accept = &accept
+	return r
+}
 func (r ApiExportDataRequest) ForBrowser(forBrowser bool) ApiExportDataRequest {
 	r.forBrowser = &forBrowser
 	return r
@@ -608,6 +613,9 @@ func (a *AdminApiService) ExportDataExecute(r ApiExportDataRequest) (*os.File, *
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.accept != nil {
+		localVarHeaderParams["Accept"] = parameterToString(*r.accept, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {

--- a/registryinstance/apiv1internal/client/docs/AdminApi.md
+++ b/registryinstance/apiv1internal/client/docs/AdminApi.md
@@ -156,7 +156,7 @@ No authorization required
 
 ## ExportData
 
-> *os.File ExportData(ctx).ForBrowser(forBrowser).Execute()
+> *os.File ExportData(ctx).Accept(accept).ForBrowser(forBrowser).Execute()
 
 Export registry data
 
@@ -175,11 +175,12 @@ import (
 )
 
 func main() {
+    accept := "accept_example" // string |  (optional)
     forBrowser := true // bool | Indicates if the operation is done for a browser.  If true, the response will be a JSON payload with a property called `href`.  This `href` will be a single-use, naked download link suitable for use by a web browser to download the content. (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.AdminApi.ExportData(context.Background()).ForBrowser(forBrowser).Execute()
+    resp, r, err := api_client.AdminApi.ExportData(context.Background()).Accept(accept).ForBrowser(forBrowser).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AdminApi.ExportData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -200,6 +201,7 @@ Other parameters are passed through a pointer to a apiExportDataRequest struct v
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **accept** | **string** |  | 
  **forBrowser** | **bool** | Indicates if the operation is done for a browser.  If true, the response will be a JSON payload with a property called &#x60;href&#x60;.  This &#x60;href&#x60; will be a single-use, naked download link suitable for use by a web browser to download the content. | 
 
 ### Return type


### PR DESCRIPTION
Addresses [app-services-cli#1774](https://github.com/redhat-developer/app-services-cli/issues/1774).

Specifying `Accept` as an parameter will allow CLI to pass `application/zip` as content type of request.