### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/build_and_validate.yaml
+++ b/.github/workflows/build_and_validate.yaml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+        # v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
         id: filter
         with:
           base: main
@@ -41,7 +42,8 @@ jobs:
         run: ./scripts/go-mod-check.sh
       - name: golangci-lint
         if: steps.filter.outputs.go == 'true'
-        uses: golangci/golangci-lint-action@v3
+        # v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
         with:
           version: v1.43
           args: --timeout 2m0s

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -25,7 +25,8 @@ jobs:
           ./scripts/generate.sh
           go mod tidy
 
-      - uses: peter-evans/create-pull-request@v4
+        # v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
           title: "chore(all): re-generate OpenAPI client(s)"
           token: "${{ secrets.CI_USER_TOKEN }}"

--- a/.github/workflows/generate_errors.yaml
+++ b/.github/workflows/generate_errors.yaml
@@ -23,7 +23,8 @@ jobs:
         run: ./scripts/errors/fetch-errors.sh
       - name: Generate Errors SDK
         run: ./scripts/errors/generate-errors.sh
-      - uses: peter-evans/create-pull-request@v4
+        # v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
           title: "fix(all): regenerated Error SDK(s)"
           token: "${{ secrets.CI_USER_TOKEN }}"

--- a/.github/workflows/push_registry_sdk.yaml
+++ b/.github/workflows/push_registry_sdk.yaml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v3
      
       - name: KAS Fleet Manager OpenAPI changed
-        uses: peter-evans/repository-dispatch@v2
+        # v2
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
           token: ${{ env.APP_SERVICES_CI_TOKEN }}
           repository: ${{ matrix.repo }}

--- a/.github/workflows/push_security_sdk.yaml
+++ b/.github/workflows/push_security_sdk.yaml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v3
      
       - name: KAS Fleet Manager OpenAPI changed
-        uses: peter-evans/repository-dispatch@v2
+        # v2
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
           token: ${{ env.APP_SERVICES_CI_TOKEN }}
           repository: ${{ matrix.repo }}

--- a/.github/workflows/update_openapi.yaml
+++ b/.github/workflows/update_openapi.yaml
@@ -35,7 +35,8 @@ jobs:
       - name: Fetch OpenAPI doc
         if: github.event.client_payload.download_url != ''
         run: ./scripts/fetch_api.sh ${{ github.event.client_payload.download_url }}
-      - uses: peter-evans/create-pull-request@v4
+        # v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
           title: "chore(openapi): update ${{ env.CLIENT_ID }} OpenAPI document"
           token: "${{ secrets.CI_USER_TOKEN }}"


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.